### PR TITLE
Add `features` param to `EightBall.marshall`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.0]
+ - Add `features` parameter to `EightBall.marshall` to allow marshalling any Features, not just the ones
+   from the configured Provider.
+
 ## [2.0.0]
  - [BREAKING] `Parsers` have been replaced with `Marshallers`, allowing bi-directional conversions
  - Added `EightBall.marshall` as a way to output the Feature list to an external format (e.g. to create a JSON file)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eight_ball (2.0.0)
+    eight_ball (2.1.0)
       awrence (~> 1.1)
       plissken (~> 1.2)
 

--- a/lib/eight_ball.rb
+++ b/lib/eight_ball.rb
@@ -116,7 +116,7 @@ module EightBall
   # If the {EightBall::Providers Provider} does not expose a
   # {EightBall::Marshallers Marshaller}, this will default to the
   # {EightBall::Marshallers::Json JSON Marshaller}.
-  def self.marshall(marshaller = nil)
+  def self.marshall(marshaller = nil, features = EightBall.features)
     marshaller ||=
       (provider.respond_to?(:marshaller) && provider.marshaller) ||
       EightBall::Marshallers::Json.new

--- a/lib/eight_ball/version.rb
+++ b/lib/eight_ball/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EightBall
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/spec/eight_ball_spec.rb
+++ b/spec/eight_ball_spec.rb
@@ -86,6 +86,23 @@ describe EightBall do
     end
 
     describe 'marshall' do
+      it 'uses the given features' do
+        marshaller_double = double
+        features_double = double
+
+        expect(marshaller_double).to receive(:marshall).with features_double
+
+        EightBall.marshall(marshaller_double, features_double)
+      end
+
+      it 'falls back to the features from the Provider if none are passed in' do
+        marshaller_double = double
+
+        expect(marshaller_double).to receive(:marshall).with EightBall.features
+
+        EightBall.marshall(marshaller_double)
+      end
+
       it 'uses the given Marshaller' do
         marshaller_double = double
 


### PR DESCRIPTION
Allowing a little more flexibility with how `EightBall.marshall` can be called. Passing in the Features, instead of relying on those returned by the Provider, can allow new use cases like creating a JSON file based on new or updated Feature lists, creating the file for the first time, etc.