### PR TITLE
chore(): pin third party gh action to sha

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -2,7 +2,7 @@ name: tag-and-release
 
 on:
   push:
-    branches: 
+    branches:
       - main
     paths: 'lib/*/version.rb'
 
@@ -27,7 +27,7 @@ jobs:
         echo version_tag=v$version >> $GITHUB_OUTPUT
 
     - name: Tag commit
-      uses: tvdias/github-tagger@v0.0.1
+      uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         tag: "${{steps.get_version.outputs.version_tag}}"
@@ -61,9 +61,9 @@ jobs:
       run: |
         # Must use a temporary file or it loses the formatting
         VERSION=${{steps.get_version.outputs.version}}; awk "/## \[$VERSION\]/{flag=1;next}/## \[/{flag=0}flag" CHANGELOG.md > REL-BODY.md
-        
+
     - name: Create Release
-      uses: ncipollo/release-action@v1
+      uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e
       with:
         tag: ${{steps.get_version.outputs.version_tag}}
         artifacts: "*.gem, CHANGELOG.md"

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -27,7 +27,7 @@ jobs:
         echo version_tag=v$version >> $GITHUB_OUTPUT
 
     - name: Tag commit
-      uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d
+      uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         tag: "${{steps.get_version.outputs.version_tag}}"
@@ -63,7 +63,7 @@ jobs:
         VERSION=${{steps.get_version.outputs.version}}; awk "/## \[$VERSION\]/{flag=1;next}/## \[/{flag=0}flag" CHANGELOG.md > REL-BODY.md
 
     - name: Create Release
-      uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e
+      uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.13.0
       with:
         tag: ${{steps.get_version.outputs.version_tag}}
         artifacts: "*.gem, CHANGELOG.md"


### PR DESCRIPTION
- Update third party GHA to use SHA
- Update tvdias/github-tagger to v0.0.2
- Update ncipollo/release-action to v1.13.0