### PR TITLE
Fix/garrett rewind/ec 2881/fix error logging to nucleus membrane loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.0.0]
+
+- Removes passing block to logger for `http.rb` and `json.rb`
+- Updates developer dependancies
+
 ## [2.2.1]
 
 - Switch release to github actions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,6 @@ GEM
     yard (0.9.37)
 
 PLATFORMS
-  arm64-darwin-23
   ruby
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eight_ball (2.2.0)
+    eight_ball (3.0.0)
       awrence (~> 1.1)
       plissken (~> 1.2)
 
@@ -9,69 +9,74 @@ GEM
   remote: https://rubygems.org/
   specs:
     ansi (1.5.0)
-    awrence (1.1.1)
+    awrence (1.2.1)
+    bigdecimal (3.1.8)
     byebug (11.1.3)
     coderay (1.1.3)
-    diff-lcs (1.3)
-    docile (1.3.2)
+    diff-lcs (1.5.1)
+    docile (1.4.1)
     inch (0.8.0)
       pry
       sparkr (>= 0.2.0)
       term-ansicolor
       yard (~> 0.9.12)
-    method_source (1.0.0)
-    plissken (1.3.1)
-    pry (0.13.1)
+    method_source (1.1.0)
+    plissken (1.4.1)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
+    pry-byebug (3.10.1)
       byebug (~> 11.0)
-      pry (~> 0.13.0)
-    rake (13.0.1)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+      pry (>= 0.13, < 0.15)
+    rake (13.2.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
-    simplecov (0.18.5)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-    simplecov-console (0.7.2)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-console (0.9.2)
       ansi
       simplecov
       terminal-table
-    simplecov-html (0.12.2)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     sparkr (0.4.1)
     sync (0.5.0)
-    term-ansicolor (1.7.1)
+    term-ansicolor (1.11.2)
       tins (~> 1.0)
-    terminal-table (1.8.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
-    tins (1.25.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    tins (1.37.1)
+      bigdecimal
       sync
-    unicode-display_width (1.7.0)
-    yard (0.9.25)
+    unicode-display_width (2.6.0)
+    yard (0.9.37)
 
 PLATFORMS
+  arm64-darwin-23
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.17)
+  bundler (~> 2)
   eight_ball!
   inch (~> 0.8)
-  pry-byebug (~> 3.6)
+  pry-byebug (~> 3)
   rake (~> 13.0)
-  rspec (~> 3.9.0)
+  rspec (~> 3)
   simplecov (~> 0.16)
   simplecov-console (~> 0.4)
 
 BUNDLED WITH
-   1.17.2
+   2.5.20

--- a/eight_ball.gemspec
+++ b/eight_ball.gemspec
@@ -28,11 +28,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'plissken', '~> 1.2'
 
   # Development
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'inch', '~> 0.8'
-  spec.add_development_dependency 'pry-byebug', '~> 3.6'
+  spec.add_development_dependency 'pry-byebug', '~> 3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.9.0'
+  spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'simplecov', '~> 0.16'
   spec.add_development_dependency 'simplecov-console', '~> 0.4'
 end

--- a/lib/eight_ball/marshallers/json.rb
+++ b/lib/eight_ball/marshallers/json.rb
@@ -73,7 +73,7 @@ module EightBall::Marshallers
         EightBall::Feature.new feature[:name], enabled_for, disabled_for
       end
     rescue JSON::ParserError => e
-      EightBall.logger.error { "Failed to parse JSON: #{e.message}" }
+      EightBall.logger.error "Failed to parse JSON: #{e.message}"
       []
     end
 

--- a/lib/eight_ball/providers/http.rb
+++ b/lib/eight_ball/providers/http.rb
@@ -54,7 +54,7 @@ module EightBall::Providers
     def fetch
       @features = @marshaller.unmarshall Net::HTTP.get(@uri)
     rescue StandardError => e
-      EightBall.logger.error { "Failed to fetch data from #{@uri}: #{e.message}" }
+      EightBall.logger.error "Failed to fetch data from #{@uri}: #{e.message}"
       @features = []
     end
   end

--- a/lib/eight_ball/version.rb
+++ b/lib/eight_ball/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EightBall
-  VERSION = '2.2.1'
+  VERSION = '3.0.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
 
   require 'eight_ball'
 
-  require 'pry'
+  require 'pry-byebug'
 
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
This changes the call to logger's error to pass a string parameter instead of a block, which some loggers can't handle correctly.

Additionally, updated the dev dependancies, and swapped `pry` for `pry-byebug` which was included but wasn't previously being used.