### PR TITLE
feat: release Ruby 3.3.10 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.1.0]
+
+- Upgrade Ruby to 3.3.10
+
 ## [3.0.1]
 
 - Fix release workflow to use ruby/setup-ruby instead of actions/setup-ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eight_ball (3.0.1)
+    eight_ball (3.1.0)
       awrence (~> 1.1)
       logger (~> 1.7)
       plissken (~> 1.2)

--- a/lib/eight_ball/version.rb
+++ b/lib/eight_ball/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EightBall
-  VERSION = '3.0.1'
+  VERSION = '3.1.0'
 end


### PR DESCRIPTION
## Summary
- Bump version to 3.1.0 for the Ruby 3.3.10 upgrade
- Update CHANGELOG.md

## Jira
https://rewind.atlassian.net/browse/EC-4270