### PR TITLE
fix: loosen required_ruby_version to >= 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.1.1]
+
+- Loosen `required_ruby_version` to `>= 3.2` for Edge compatibility (EC-4270)
+
 ## [3.1.0]
 
 - Upgrade Ruby to 3.3.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eight_ball (3.1.0)
+    eight_ball (3.1.1)
       awrence (~> 1.1)
       logger (~> 1.7)
       plissken (~> 1.2)

--- a/eight_ball.gemspec
+++ b/eight_ball.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/rewindio/eight_ball'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 3.3'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|.github|examples)/}) }
   spec.bindir        = 'exe'

--- a/lib/eight_ball/version.rb
+++ b/lib/eight_ball/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EightBall
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
Edge apps on Ruby 3.2.8 can't install the gem with >= 3.3 constraint.

Manual version bump to 3.1.1 and CHANGELOG entry added (eight_ball uses manual version management).

EC-4270