### PR TITLE
chore: update CODEOWNERS team ref to rewind-community

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # @rewindio/codeowners will be requested for review when someone
 # opens a pull request.
 
-* @rewindio/developers
+* @rewind-community/developers


### PR DESCRIPTION
# **Jira:** [DEVOPS-4349](https://rewind.atlassian.net/browse/DEVOPS-4349)

## Description of Change

This repo was moved from `rewindio` to `rewind-community` as part of the OSS-repo classification cleanup (terraform side: rewindio/terraform-rewindio-github#369). The existing `@rewindio/developers` reference is silently dropped by GitHub because team references can't cross organizations — swapping to `@rewind-community/developers` (same team name in the new org) restores reviewer assignment.

## Related PRs

- rewindio/terraform-rewindio-github#369 (gem batch TF move)

## Testing Performed

Single-line CODEOWNERS update — no code paths affected. GitHub will pick up the new team reference on next PR.

[DEVOPS-4349]: https://rewind.atlassian.net/browse/DEVOPS-4349