### PR TITLE
feat: add percentage condition, unmarshaller hardening, and optional metadata (3.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [3.3.0]
 
-- Add `percentage` condition for sticky A/B bucketing. Canonical algorithm: `bucket = Integer(SHA256("<flagName>:<value>")[0,8], 16) % 100`, satisfied iff `bucket < percentage`; salted by flag name; default parameter `organization_id`.- Harden JSON unmarshalling: a flag containing an unknown or malformed condition (unknown `type`, or a known type with invalid params) now evaluates to `false` (OFF) and logs a warning, instead of raising and blacking out the entire feature set. Other flags in the blob are unaffected.- Add optional top-level `metadata` (`type`, `owner`, `expires_at`) to `Feature`, preserved through marshall/unmarshall and ignored during evaluation.
+- Add `percentage` condition for sticky A/B bucketing. Canonical algorithm: `bucket = Integer(SHA256("<flagName>:<value>")[0,8], 16) % 100`, satisfied iff `bucket < percentage`; salted by flag name; default parameter `organization_id`.
+- Harden JSON unmarshalling: a flag containing an unknown or malformed condition (unknown `type`, or a known type with invalid params) now evaluates to `false` (OFF) and logs a warning, instead of raising and blacking out the entire feature set. Other flags in the blob are unaffected.
+- Add optional top-level `metadata` (`type`, `owner`, `expires_at`) to `Feature`, preserved through marshall/unmarshall and ignored during evaluation.
+
 ## [3.2.0]
 
 - Upgrade Ruby to 3.4.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [3.3.0]
+
+- Add `percentage` condition for sticky A/B bucketing. Canonical algorithm: `bucket = Integer(SHA256("<flagName>:<value>")[0,8], 16) % 100`, satisfied iff `bucket < percentage`; salted by flag name; default parameter `organization_id`.- Harden JSON unmarshalling: a flag containing an unknown or malformed condition (unknown `type`, or a known type with invalid params) now evaluates to `false` (OFF) and logs a warning, instead of raising and blacking out the entire feature set. Other flags in the blob are unaffected.- Add optional top-level `metadata` (`type`, `owner`, `expires_at`) to `Feature`, preserved through marshall/unmarshall and ignored during evaluation.
 ## [3.2.0]
 
 - Upgrade Ruby to 3.4.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [3.3.0]
 
-- Add `percentage` condition for sticky A/B bucketing. Canonical algorithm: `bucket = Integer(SHA256("<flagName>:<value>")[0,8], 16) % 100`, satisfied iff `bucket < percentage`; salted by flag name; default parameter `organization_id`.
+- Add `percentage` condition for sticky A/B bucketing. Canonical algorithm: `bucket = Integer(SHA256("<flagName>:<value>")[0,8], 16) % 100`, satisfied iff `bucket < percentage`; salted by flag name; buckets on a caller-supplied parameter.
 - Harden JSON unmarshalling: a flag containing an unknown or malformed condition (unknown `type`, or a known type with invalid params) now evaluates to `false` (OFF) and logs a warning, instead of raising and blacking out the entire feature set. Other flags in the blob are unaffected.
 - Add optional top-level `metadata` (`type`, `owner`, `expires_at`) to `Feature`, preserved through marshall/unmarshall and ignored during evaluation.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eight_ball (3.2.0)
+    eight_ball (3.3.0)
       awrence (~> 1.1)
       logger (~> 1.7)
       plissken (~> 1.2)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The salt is the **flag name**, so the same `account_id` lands in independent buc
 
 ### Metadata
 
-A Feature may carry an optional, eval-agnostic `metadata` object (`type`, `owner`, `expires_at`, all optional strings). It is preserved through marshall/unmarshall and ignored during evaluation.
+A Feature may carry an optional, eval-agnostic `metadata` object (`type`, `owner`, `expires_at`, all optional strings). It is preserved through marshall/unmarshall and ignored during evaluation. Its keys go through the same case conversion as the rest of the wire format (e.g. `expires_at` serializes as `expiresAt`) and come back symbol-keyed after unmarshall.
 
 ### Provider
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ A Condition must either be `true` or `false`. It describes when a Feature is ena
 - [List](lib/eight_ball/conditions/list.rb): This condition is satisfied if the given value belongs to its list of accepted values.
 - [Never](lib/eight_ball/conditions/never.rb): This condition is never satisfied.
 - [Range](lib/eight_ball/conditions/range.rb): This condition is satisfied if the given value is within the specified range (inclusive).
+- [Percentage](lib/eight_ball/conditions/percentage.rb): This condition is satisfied for a deterministic, sticky subset of subjects sized to `percentage` percent. Bucketing is salted by the flag name so a subject is decorrelated across flags. Wire form: `{"type":"percentage","parameter":"organization_id","percentage":<0..100>}`.
+
+#### Sticky percentage bucketing (spec of record)
+
+The `percentage` condition buckets a subject deterministically:
+
+```
+bucket = Integer(Digest::SHA256.hexdigest("#{flagName}:#{value}")[0, 8], 16) % 100
+satisfied  iff  bucket < percentage
+```
+
+The salt is the **flag name**, so the same `organization_id` lands in independent buckets across different flags. `value` is stringified before hashing. This is the canonical algorithm; any future port (e.g. a TypeScript SDK) must reproduce it exactly to stay consistent with the Ruby evaluator.
+
+**Re-randomizing requires a rename.** Because the salt is the flag name, an experiment cannot be re-randomized on the same flag. The salt is stable for the life of the name (this is what decorrelates an org across flags), so an org's bucket for a given flag is fixed forever. Changing `percentage` only moves the threshold (it does not reshuffle buckets); to draw fresh buckets, rename the flag.
+
+**Requires the bucketing parameter.** Like every parameterized condition, `percentage` requires its bucketing value (by default `organization_id`) in the evaluation bag. If it is absent, evaluation raises `ArgumentError`; supply it or rescue.
+
+### Metadata
+
+A Feature may carry an optional, eval-agnostic `metadata` object (`type`, `owner`, `expires_at`, all optional strings). It is preserved through marshall/unmarshall and ignored during evaluation.
 
 ### Provider
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ A Condition must either be `true` or `false`. It describes when a Feature is ena
 - [Range](lib/eight_ball/conditions/range.rb): This condition is satisfied if the given value is within the specified range (inclusive).
 - [Percentage](lib/eight_ball/conditions/percentage.rb): This condition is satisfied for a deterministic, sticky subset of subjects sized to `percentage` percent. Bucketing is salted by the flag name so a subject is decorrelated across flags. Wire form: `{"type":"percentage","parameter":"account_id","percentage":<0..100>}`.
 
-#### Sticky percentage bucketing (spec of record)
+#### Sticky percentage bucketing
 
 The `percentage` condition buckets a subject deterministically:
 
@@ -92,7 +92,7 @@ bucket = Integer(Digest::SHA256.hexdigest("#{flagName}:#{value}")[0, 8], 16) % 1
 satisfied  iff  bucket < percentage
 ```
 
-The salt is the **flag name**, so the same `account_id` lands in independent buckets across different flags. `value` is stringified before hashing. This is the canonical algorithm; any future port (e.g. a TypeScript SDK) must reproduce it exactly to stay consistent with the Ruby evaluator.
+The salt is the **flag name**, so the same `account_id` lands in independent buckets across different flags. `value` is stringified before hashing. Any reimplementation must reproduce it exactly to produce the same buckets.
 
 **Re-randomizing requires a rename.** Because the salt is the flag name, an experiment cannot be re-randomized on the same flag. The salt is stable for the life of the name (this is what decorrelates a subject across flags), so a subject's bucket for a given flag is fixed forever. Changing `percentage` only moves the threshold (it does not reshuffle buckets); to draw fresh buckets, rename the flag.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A Condition must either be `true` or `false`. It describes when a Feature is ena
 - [List](lib/eight_ball/conditions/list.rb): This condition is satisfied if the given value belongs to its list of accepted values.
 - [Never](lib/eight_ball/conditions/never.rb): This condition is never satisfied.
 - [Range](lib/eight_ball/conditions/range.rb): This condition is satisfied if the given value is within the specified range (inclusive).
-- [Percentage](lib/eight_ball/conditions/percentage.rb): This condition is satisfied for a deterministic, sticky subset of subjects sized to `percentage` percent. Bucketing is salted by the flag name so a subject is decorrelated across flags. Wire form: `{"type":"percentage","parameter":"organization_id","percentage":<0..100>}`.
+- [Percentage](lib/eight_ball/conditions/percentage.rb): This condition is satisfied for a deterministic, sticky subset of subjects sized to `percentage` percent. Bucketing is salted by the flag name so a subject is decorrelated across flags. Wire form: `{"type":"percentage","parameter":"account_id","percentage":<0..100>}`.
 
 #### Sticky percentage bucketing (spec of record)
 
@@ -92,11 +92,11 @@ bucket = Integer(Digest::SHA256.hexdigest("#{flagName}:#{value}")[0, 8], 16) % 1
 satisfied  iff  bucket < percentage
 ```
 
-The salt is the **flag name**, so the same `organization_id` lands in independent buckets across different flags. `value` is stringified before hashing. This is the canonical algorithm; any future port (e.g. a TypeScript SDK) must reproduce it exactly to stay consistent with the Ruby evaluator.
+The salt is the **flag name**, so the same `account_id` lands in independent buckets across different flags. `value` is stringified before hashing. This is the canonical algorithm; any future port (e.g. a TypeScript SDK) must reproduce it exactly to stay consistent with the Ruby evaluator.
 
-**Re-randomizing requires a rename.** Because the salt is the flag name, an experiment cannot be re-randomized on the same flag. The salt is stable for the life of the name (this is what decorrelates an org across flags), so an org's bucket for a given flag is fixed forever. Changing `percentage` only moves the threshold (it does not reshuffle buckets); to draw fresh buckets, rename the flag.
+**Re-randomizing requires a rename.** Because the salt is the flag name, an experiment cannot be re-randomized on the same flag. The salt is stable for the life of the name (this is what decorrelates a subject across flags), so a subject's bucket for a given flag is fixed forever. Changing `percentage` only moves the threshold (it does not reshuffle buckets); to draw fresh buckets, rename the flag.
 
-**Requires the bucketing parameter.** Like every parameterized condition, `percentage` requires its bucketing value (by default `organization_id`) in the evaluation bag. If it is absent, evaluation raises `ArgumentError`; supply it or rescue.
+**Requires the bucketing parameter.** Like every parameterized condition, `percentage` requires its bucketing value (the `parameter` it was configured with) in the evaluation bag. If it is absent, evaluation raises `ArgumentError`; supply it or rescue.
 
 ### Metadata
 

--- a/lib/eight_ball.rb
+++ b/lib/eight_ball.rb
@@ -11,6 +11,7 @@ require 'eight_ball/conditions/base'
 require 'eight_ball/conditions/always'
 require 'eight_ball/conditions/list'
 require 'eight_ball/conditions/never'
+require 'eight_ball/conditions/opaque'
 require 'eight_ball/conditions/percentage'
 require 'eight_ball/conditions/range'
 

--- a/lib/eight_ball.rb
+++ b/lib/eight_ball.rb
@@ -11,6 +11,7 @@ require 'eight_ball/conditions/base'
 require 'eight_ball/conditions/always'
 require 'eight_ball/conditions/list'
 require 'eight_ball/conditions/never'
+require 'eight_ball/conditions/percentage'
 require 'eight_ball/conditions/range'
 
 require 'eight_ball/marshallers/json'

--- a/lib/eight_ball/conditions/base.rb
+++ b/lib/eight_ball/conditions/base.rb
@@ -21,6 +21,22 @@ module EightBall::Conditions
       state.hash
     end
 
+    # The wire-format hash for this condition. Subclasses declare their fields via
+    # {wire_fields}; the type is derived from the class name.
+    def to_wire
+      wire = { type: self.class.name.split('::').last.downcase }
+      wire_fields.each do |field|
+        value = public_send(field)
+        wire[field.to_s] = value unless value.nil?
+      end
+      wire
+    end
+
+    # The attributes this condition serializes, in output order (default: none).
+    def wire_fields
+      []
+    end
+
     protected
 
     def state

--- a/lib/eight_ball/conditions/base.rb
+++ b/lib/eight_ball/conditions/base.rb
@@ -22,7 +22,8 @@ module EightBall::Conditions
     end
 
     # The wire-format hash for this condition. Subclasses declare their fields via
-    # {wire_fields}; the type is derived from the class name.
+    # {wire_fields}; the type is the lower-cased class name, which must match a
+    # {EightBall::Conditions.by_name} key so the condition round-trips.
     def to_wire
       wire = { type: self.class.name.split('::').last.downcase }
       wire_fields.each do |field|

--- a/lib/eight_ball/conditions/conditions.rb
+++ b/lib/eight_ball/conditions/conditions.rb
@@ -9,6 +9,7 @@ module EightBall::Conditions
       always: EightBall::Conditions::Always,
       list: EightBall::Conditions::List,
       never: EightBall::Conditions::Never,
+      percentage: EightBall::Conditions::Percentage,
       range: EightBall::Conditions::Range
     }
     mappings[name.downcase.to_sym]

--- a/lib/eight_ball/conditions/conditions.rb
+++ b/lib/eight_ball/conditions/conditions.rb
@@ -5,6 +5,8 @@ module EightBall::Conditions
   # @param [String] name The case insensitive name to find the Condition for
   # @return [EightBall::Conditions] the Condition class represented by the given name
   def self.by_name(name)
+    return nil unless name.is_a?(String)
+
     mappings = {
       always: EightBall::Conditions::Always,
       list: EightBall::Conditions::List,

--- a/lib/eight_ball/conditions/list.rb
+++ b/lib/eight_ball/conditions/list.rb
@@ -32,6 +32,10 @@ module EightBall::Conditions
       values.include? value
     end
 
+    def wire_fields
+      %i[values parameter]
+    end
+
     protected
 
     def state

--- a/lib/eight_ball/conditions/opaque.rb
+++ b/lib/eight_ball/conditions/opaque.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module EightBall::Conditions
+  # Wraps a condition entry that could not be built (unknown type, invalid params,
+  # or a non-object entry). It is never satisfiable and re-serializes to its
+  # original raw input, so a Feature holding one is failed closed yet round-trips
+  # verbatim. Not registered in {by_name}; produced only as a parse fallback.
+  class Opaque < Base
+    attr_reader :raw
+
+    def initialize(raw)
+      @raw = raw
+    end
+
+    def satisfied?(*)
+      false
+    end
+
+    # Re-emit the original entry unchanged.
+    def to_wire
+      @raw
+    end
+
+    protected
+
+    def state
+      [@raw]
+    end
+  end
+end

--- a/lib/eight_ball/conditions/percentage.rb
+++ b/lib/eight_ball/conditions/percentage.rb
@@ -46,6 +46,10 @@ module EightBall::Conditions
       bucket < @percentage
     end
 
+    def wire_fields
+      %i[percentage parameter]
+    end
+
     protected
 
     # flag_name is a runtime injection, excluded from equality and the wire form.

--- a/lib/eight_ball/conditions/percentage.rb
+++ b/lib/eight_ball/conditions/percentage.rb
@@ -3,34 +3,18 @@
 require 'digest'
 
 module EightBall::Conditions
-  # The Percentage Condition implements sticky percentage bucketing for
-  # A/B experiments. It is satisfied for a deterministic subset of values
-  # sized to +percentage+ percent.
-  #
-  # Canonical bucket algorithm (spec of record):
-  #   bucket = Integer(Digest::SHA256.hexdigest("\#{flag_name}:\#{value}")[0, 8], 16) % 100
-  #   satisfied iff bucket < percentage
-  #
-  # The salt is the owning flag's name, so a given value (e.g. an
-  # account_id) is decorrelated across different flags/experiments.
-  # +flag_name+ is injected by {EightBall::Feature} at construction time
-  # because Conditions do not otherwise know which Feature owns them.
-  #
-  # Limitation (by design): because the bucket salt is the flag name, an
-  # experiment CANNOT be re-randomized on the same flag. The salt is stable for
-  # the life of the name, which is what decorrelates a subject across flags but also
-  # fixes that subject's bucket for that flag forever. To re-draw buckets (a fresh
-  # randomization) you must rename the flag (a new name is a new salt). Changing
-  # +percentage+ only moves the threshold; it does not reshuffle who is in which
-  # bucket.
+  # The Percentage Condition is satisfied for a deterministic, sticky subset of
+  # values sized to +percentage+ percent. Bucketing is salted by the owning flag's
+  # name (injected by {EightBall::Feature}), so a value buckets independently per
+  # flag. See the README for the bucket algorithm.
   class Percentage < Base
     attr_reader :percentage, :flag_name
 
     # @param [Hash] options
     # @option options [Integer] :percentage Integer 0..100. 0 is never
     #   satisfied; 100 is always satisfied.
-    # @option options [String] :parameter The attribute to bucket on
-    #   (e.g. "account_id"). Caller-supplied, like the other parameterized conditions.
+    # @option options [String] :parameter The name of the parameter this Condition
+    #   was created for (eg. "account_id").
     def initialize(options = {})
       options ||= {}
 
@@ -58,15 +42,13 @@ module EightBall::Conditions
     def satisfied?(value)
       raise ArgumentError, 'flag_name has not been set on Percentage condition' if @flag_name.nil?
 
-      # SHA256 here is a non-cryptographic hash chosen for uniform bucket distribution, not security.
       bucket = Integer(Digest::SHA256.hexdigest("#{@flag_name}:#{value}")[0, 8], 16) % 100
       bucket < @percentage
     end
 
     protected
 
-    # NOTE: flag_name is deliberately excluded from state/equality and from the
-    # wire format; it is a runtime injection, not part of the flag definition.
+    # flag_name is a runtime injection, excluded from equality and the wire form.
     def state
       super + [@percentage]
     end

--- a/lib/eight_ball/conditions/percentage.rb
+++ b/lib/eight_ball/conditions/percentage.rb
@@ -12,14 +12,14 @@ module EightBall::Conditions
   #   satisfied iff bucket < percentage
   #
   # The salt is the owning flag's name, so a given value (e.g. an
-  # organization_id) is decorrelated across different flags/experiments.
+  # account_id) is decorrelated across different flags/experiments.
   # +flag_name+ is injected by {EightBall::Feature} at construction time
   # because Conditions do not otherwise know which Feature owns them.
   #
   # Limitation (by design): because the bucket salt is the flag name, an
   # experiment CANNOT be re-randomized on the same flag. The salt is stable for
-  # the life of the name, which is what decorrelates an org across flags but also
-  # fixes that org's bucket for that flag forever. To re-draw buckets (a fresh
+  # the life of the name, which is what decorrelates a subject across flags but also
+  # fixes that subject's bucket for that flag forever. To re-draw buckets (a fresh
   # randomization) you must rename the flag (a new name is a new salt). Changing
   # +percentage+ only moves the threshold; it does not reshuffle who is in which
   # bucket.
@@ -29,9 +29,8 @@ module EightBall::Conditions
     # @param [Hash] options
     # @option options [Integer] :percentage Integer 0..100. 0 is never
     #   satisfied; 100 is always satisfied.
-    # @option options [String] :parameter The attribute to bucket on.
-    #   Defaults to "organization_id"; use "account_id" for instance-scoped
-    #   experiments.
+    # @option options [String] :parameter The attribute to bucket on
+    #   (e.g. "account_id"). Caller-supplied, like the other parameterized conditions.
     def initialize(options = {})
       options ||= {}
 
@@ -45,7 +44,7 @@ module EightBall::Conditions
       @percentage = percentage
       @flag_name = nil
 
-      self.parameter = options[:parameter] || 'organization_id'
+      self.parameter = options[:parameter]
     end
 
     # Injected by {EightBall::Feature} so the bucket can be salted by flag name.

--- a/lib/eight_ball/conditions/percentage.rb
+++ b/lib/eight_ball/conditions/percentage.rb
@@ -21,6 +21,7 @@ module EightBall::Conditions
       raise ArgumentError, 'Missing value for percentage' if options[:percentage].nil?
 
       percentage = options[:percentage]
+      percentage = percentage.to_i if percentage.is_a?(Float) && percentage.to_i == percentage
       unless percentage.is_a?(Integer) && percentage >= 0 && percentage <= 100
         raise ArgumentError, 'percentage must be an integer between 0 and 100'
       end

--- a/lib/eight_ball/conditions/percentage.rb
+++ b/lib/eight_ball/conditions/percentage.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'digest'
+
+module EightBall::Conditions
+  # The Percentage Condition implements sticky percentage bucketing for
+  # A/B experiments. It is satisfied for a deterministic subset of values
+  # sized to +percentage+ percent.
+  #
+  # Canonical bucket algorithm (spec of record):
+  #   bucket = Integer(Digest::SHA256.hexdigest("\#{flag_name}:\#{value}")[0, 8], 16) % 100
+  #   satisfied iff bucket < percentage
+  #
+  # The salt is the owning flag's name, so a given value (e.g. an
+  # organization_id) is decorrelated across different flags/experiments.
+  # +flag_name+ is injected by {EightBall::Feature} at construction time
+  # because Conditions do not otherwise know which Feature owns them.
+  #
+  # Limitation (by design): because the bucket salt is the flag name, an
+  # experiment CANNOT be re-randomized on the same flag. The salt is stable for
+  # the life of the name, which is what decorrelates an org across flags but also
+  # fixes that org's bucket for that flag forever. To re-draw buckets (a fresh
+  # randomization) you must rename the flag (a new name is a new salt). Changing
+  # +percentage+ only moves the threshold; it does not reshuffle who is in which
+  # bucket.
+  class Percentage < Base
+    attr_reader :percentage, :flag_name
+
+    # @param [Hash] options
+    # @option options [Integer] :percentage Integer 0..100. 0 is never
+    #   satisfied; 100 is always satisfied.
+    # @option options [String] :parameter The attribute to bucket on.
+    #   Defaults to "organization_id"; use "account_id" for instance-scoped
+    #   experiments.
+    def initialize(options = {})
+      options ||= {}
+
+      raise ArgumentError, 'Missing value for percentage' if options[:percentage].nil?
+
+      percentage = options[:percentage]
+      unless percentage.is_a?(Integer) && percentage >= 0 && percentage <= 100
+        raise ArgumentError, 'percentage must be an integer between 0 and 100'
+      end
+
+      @percentage = percentage
+      @flag_name = nil
+
+      self.parameter = options[:parameter] || 'organization_id'
+    end
+
+    # Injected by {EightBall::Feature} so the bucket can be salted by flag name.
+    def flag_name=(name)
+      @flag_name = name
+    end
+
+    # @param value The value of {parameter} for the subject being evaluated.
+    # @return [Boolean] whether the subject falls within the bucket.
+    # @raise [ArgumentError] if {flag_name} was never injected.
+    def satisfied?(value)
+      raise ArgumentError, 'flag_name has not been set on Percentage condition' if @flag_name.nil?
+
+      # SHA256 here is a non-cryptographic hash chosen for uniform bucket distribution, not security.
+      bucket = Integer(Digest::SHA256.hexdigest("#{@flag_name}:#{value}")[0, 8], 16) % 100
+      bucket < @percentage
+    end
+
+    protected
+
+    # NOTE: flag_name is deliberately excluded from state/equality and from the
+    # wire format; it is a runtime injection, not part of the flag definition.
+    def state
+      super + [@percentage]
+    end
+  end
+end

--- a/lib/eight_ball/conditions/range.rb
+++ b/lib/eight_ball/conditions/range.rb
@@ -45,6 +45,10 @@ module EightBall::Conditions
       value >= min && value <= max
     end
 
+    def wire_fields
+      %i[min max parameter]
+    end
+
     protected
 
     def state

--- a/lib/eight_ball/feature.rb
+++ b/lib/eight_ball/feature.rb
@@ -73,7 +73,8 @@ module EightBall
         enabled_for.size == other.enabled_for.size &&
         enabled_for.all? { |condition| other.enabled_for.any? { |other_condition| condition == other_condition } } &&
         disabled_for.size == other.disabled_for.size &&
-        disabled_for.all? { |condition| other.disabled_for.any? { |other_condition| condition == other_condition } }
+        disabled_for.all? { |condition| other.disabled_for.any? { |other_condition| condition == other_condition } } &&
+        metadata == other.metadata
     end
     alias eql? ==
 

--- a/lib/eight_ball/feature.rb
+++ b/lib/eight_ball/feature.rb
@@ -58,16 +58,11 @@ module EightBall
       any_satisfied?(@enabled_for, parameters) && !any_satisfied?(@disabled_for, parameters)
     end
 
-    # Marks this Feature as un-evaluable. An un-evaluable Feature always
-    # reports +false+ from {enabled?} and never inspects its Conditions.
-    # Used by Marshallers to fail a single Feature closed (OFF) when its JSON
-    # contains an unknown or malformed Condition, instead of raising and taking
-    # down the whole feature set.
+    # Marks this Feature un-evaluable: {enabled?} always returns +false+ and its
+    # Conditions are never inspected. Used by Marshallers to fail a bad flag closed.
     #
-    # @param source [Hash, nil] the raw unmarshalled feature hash, retained so a
-    #   Marshaller can re-emit an unparseable flag verbatim instead of dropping
-    #   its definition (which would flip it from fail-closed OFF to fail-open ON
-    #   on the next read).
+    # @param source [Hash, nil] the raw unmarshalled feature hash, kept so a
+    #   Marshaller can re-emit the flag unchanged.
     # @return [nil]
     def un_evaluable!(source = nil)
       @un_evaluable = true
@@ -102,9 +97,8 @@ module EightBall
       end
     end
 
-    # Conditions do not know which Feature owns them, but the Percentage
-    # condition needs the flag name as its bucket salt. Inject it here, duck-typed
-    # so legacy conditions (always/never/list/range) are untouched.
+    # Percentage conditions bucket on a salt of the flag name; give any condition
+    # that accepts it the owning name. Others are untouched.
     def inject_flag_name(conditions)
       conditions.each do |condition|
         condition.flag_name = @name if condition.respond_to?(:flag_name=)

--- a/lib/eight_ball/feature.rb
+++ b/lib/eight_ball/feature.rb
@@ -4,7 +4,7 @@ module EightBall
   # A Feature is an element of your application that can be enabled or disabled
   # based on various {EightBall::Conditions}.
   class Feature
-    attr_reader :name, :enabled_for, :disabled_for
+    attr_reader :name, :enabled_for, :disabled_for, :metadata, :source
 
     # Creates a new instance of an Interval RefreshPolicy.
     #
@@ -13,13 +13,21 @@ module EightBall
     #   The Condition(s) that need to be satisfied for the Feature to be enabled.
     # @param disabled_for [Array<EightBall::Conditions>, EightBall::Conditions]
     #   The Condition(s) that need to be satisfied for the Feature to be disabled.
+    # @param metadata [Hash, nil] Optional eval-agnostic metadata
+    #   (e.g. { "type" => ..., "owner" => ..., "expires_at" => ... }).
     #
     # @example A Feature which is always enabled
     #   feature = EightBall::Feature.new 'feature1', EightBall::Conditions::Always
-    def initialize(name, enabled_for = [], disabled_for = [])
+    def initialize(name, enabled_for = [], disabled_for = [], metadata: nil)
       @name = name
       @enabled_for = Array enabled_for
       @disabled_for = Array disabled_for
+      @metadata = metadata
+      @un_evaluable = false
+      @source = nil
+
+      inject_flag_name @enabled_for
+      inject_flag_name @disabled_for
     end
 
     # "EightBall, is this Feature enabled?"
@@ -42,10 +50,34 @@ module EightBall
     # @example The Feature's {EightBall::Conditions} require an account ID
     #   feature.enabled? account_id: 123
     def enabled?(parameters = {})
+      return false if @un_evaluable
+
       return true if @enabled_for.empty? && @disabled_for.empty?
       return true if @enabled_for.empty? && !any_satisfied?(@disabled_for, parameters)
 
       any_satisfied?(@enabled_for, parameters) && !any_satisfied?(@disabled_for, parameters)
+    end
+
+    # Marks this Feature as un-evaluable. An un-evaluable Feature always
+    # reports +false+ from {enabled?} and never inspects its Conditions.
+    # Used by Marshallers to fail a single Feature closed (OFF) when its JSON
+    # contains an unknown or malformed Condition, instead of raising and taking
+    # down the whole feature set.
+    #
+    # @param source [Hash, nil] the raw unmarshalled feature hash, retained so a
+    #   Marshaller can re-emit an unparseable flag verbatim instead of dropping
+    #   its definition (which would flip it from fail-closed OFF to fail-open ON
+    #   on the next read).
+    # @return [nil]
+    def un_evaluable!(source = nil)
+      @un_evaluable = true
+      @source = source
+      nil
+    end
+
+    # @return [Boolean] whether this Feature has been marked un-evaluable.
+    def un_evaluable?
+      @un_evaluable
     end
 
     def ==(other)
@@ -67,6 +99,15 @@ module EightBall
         raise ArgumentError, "Missing parameter #{condition.parameter}" if value.nil?
 
         condition.satisfied? value
+      end
+    end
+
+    # Conditions do not know which Feature owns them, but the Percentage
+    # condition needs the flag name as its bucket salt. Inject it here, duck-typed
+    # so legacy conditions (always/never/list/range) are untouched.
+    def inject_flag_name(conditions)
+      conditions.each do |condition|
+        condition.flag_name = @name if condition.respond_to?(:flag_name=)
       end
     end
   end

--- a/lib/eight_ball/feature.rb
+++ b/lib/eight_ball/feature.rb
@@ -20,13 +20,10 @@ module EightBall
     #   feature = EightBall::Feature.new 'feature1', EightBall::Conditions::Always
     def initialize(name, enabled_for = [], disabled_for = [], metadata: nil)
       @name = name
-      @enabled_for = Array enabled_for
-      @disabled_for = Array disabled_for
+      @enabled_for = inject_flag_name(Array(enabled_for))
+      @disabled_for = inject_flag_name(Array(disabled_for))
       @metadata = metadata
       @un_evaluable = false
-
-      inject_flag_name @enabled_for
-      inject_flag_name @disabled_for
     end
 
     # "EightBall, is this Feature enabled?"
@@ -97,7 +94,7 @@ module EightBall
     # that accepts it the owning name, duping first so a condition shared across
     # Features is not re-salted in place. Others pass through untouched.
     def inject_flag_name(conditions)
-      conditions.map! do |condition|
+      conditions.map do |condition|
         next condition unless condition.respond_to?(:flag_name=)
 
         condition.dup.tap { |copy| copy.flag_name = @name }

--- a/lib/eight_ball/feature.rb
+++ b/lib/eight_ball/feature.rb
@@ -4,7 +4,7 @@ module EightBall
   # A Feature is an element of your application that can be enabled or disabled
   # based on various {EightBall::Conditions}.
   class Feature
-    attr_reader :name, :enabled_for, :disabled_for, :metadata, :source
+    attr_reader :name, :enabled_for, :disabled_for, :metadata
 
     # Creates a new instance of an Interval RefreshPolicy.
     #
@@ -24,7 +24,6 @@ module EightBall
       @disabled_for = Array disabled_for
       @metadata = metadata
       @un_evaluable = false
-      @source = nil
 
       inject_flag_name @enabled_for
       inject_flag_name @disabled_for
@@ -61,12 +60,9 @@ module EightBall
     # Marks this Feature un-evaluable: {enabled?} always returns +false+ and its
     # Conditions are never inspected. Used by Marshallers to fail a bad flag closed.
     #
-    # @param source [Hash, nil] the raw unmarshalled feature hash, kept so a
-    #   Marshaller can re-emit the flag unchanged.
     # @return [nil]
-    def un_evaluable!(source = nil)
+    def un_evaluable!
       @un_evaluable = true
-      @source = source
       nil
     end
 
@@ -97,11 +93,14 @@ module EightBall
       end
     end
 
-    # Percentage conditions bucket on a salt of the flag name; give any condition
-    # that accepts it the owning name. Others are untouched.
+    # Percentage conditions bucket on a salt of the flag name. Give any condition
+    # that accepts it the owning name, duping first so a condition shared across
+    # Features is not re-salted in place. Others pass through untouched.
     def inject_flag_name(conditions)
-      conditions.each do |condition|
-        condition.flag_name = @name if condition.respond_to?(:flag_name=)
+      conditions.map! do |condition|
+        next condition unless condition.respond_to?(:flag_name=)
+
+        condition.dup.tap { |copy| copy.flag_name = @name }
       end
     end
   end

--- a/lib/eight_ball/marshallers/json.rb
+++ b/lib/eight_ball/marshallers/json.rb
@@ -62,11 +62,11 @@ module EightBall::Marshallers
     #   marshaller = EightBall::Marshallers::Json.new
     #   marshaller.unmarshall json_string => [Features]
     def unmarshall(json)
-      parsed = JSON.parse(json, symbolize_names: true).to_snake_keys
+      parsed = JSON.parse(json, symbolize_names: true)
 
       raise ArgumentError, 'JSON input was not an array' unless parsed.is_a? Array
 
-      parsed.filter_map do |feature|
+      parsed.to_snake_keys.filter_map do |feature|
         build_feature feature
       end
     rescue JSON::ParserError => e

--- a/lib/eight_ball/marshallers/json.rb
+++ b/lib/eight_ball/marshallers/json.rb
@@ -37,6 +37,12 @@ require 'plissken'
 #   }]
 module EightBall::Marshallers
   class Json
+    # Raised internally by create_conditions_from_json when a Condition type is
+    # not recognized. Caught per-feature by unmarshall so a single bad Feature
+    # is failed closed (OFF) instead of taking down the whole feature set.
+    UnknownConditionType = Class.new(StandardError)
+    private_constant :UnknownConditionType
+
     # Convert the given {EightBall::Feature Features} into a JSON array.
     #
     # @param [Array<EightBall::Feature>] features The {EightBall::Feature Features} to convert.
@@ -67,10 +73,7 @@ module EightBall::Marshallers
       raise ArgumentError, 'JSON input was not an array' unless parsed.is_a? Array
 
       parsed.map do |feature|
-        enabled_for = create_conditions_from_json feature[:enabled_for]
-        disabled_for = create_conditions_from_json feature[:disabled_for]
-
-        EightBall::Feature.new feature[:name], enabled_for, disabled_for
+        build_feature feature
       end
     rescue JSON::ParserError => e
       EightBall.logger.error { "Failed to parse JSON: #{e.message}" }
@@ -79,25 +82,63 @@ module EightBall::Marshallers
 
     private
 
+    def build_feature(feature)
+      enabled_for = create_conditions_from_json feature[:enabled_for]
+      disabled_for = create_conditions_from_json feature[:disabled_for]
+
+      EightBall::Feature.new feature[:name], enabled_for, disabled_for, metadata: feature[:metadata]
+    rescue UnknownConditionType, ArgumentError => e
+      # Fail ONLY this flag closed (OFF) for any unbuildable condition: an unknown
+      # type OR a known type with invalid params (e.g. a range missing min). Both
+      # would otherwise raise out of unmarshall and black out the whole blob.
+      EightBall.logger.warn { "Feature '#{feature[:name]}' has an invalid condition (#{e.message}); marking it un-evaluable (OFF)" }
+      # Retain the raw source so re-marshalling re-emits the unparseable flag verbatim
+      # (keeps it fail-closed on the next read; never drops the definition).
+      EightBall::Feature.new(feature[:name], [], [], metadata: feature[:metadata]).tap { |f| f.un_evaluable! feature }
+    end
+
     def feature_to_hash(feature)
+      # An un-evaluable feature re-emits its original raw source verbatim, so a
+      # read -> marshall -> persist cycle neither drops the unparseable definition
+      # nor flips the flag from fail-closed OFF to fail-open ON.
+      return feature.source if feature.un_evaluable? && feature.source
+
       hash = {
         name: feature.name
       }
 
       hash[:enabled_for] = feature.enabled_for.map { |condition| condition_to_hash(condition) } unless feature.enabled_for.empty?
       hash[:disabled_for] = feature.disabled_for.map { |condition| condition_to_hash(condition) } unless feature.disabled_for.empty?
+      hash[:metadata] = feature.metadata unless feature.metadata.nil?
 
       hash
     end
 
-    def condition_to_hash(condition)
-      hash = {
-        type: condition.class.name.split('::').last.downcase
-      }
-      condition.instance_variables.each do |var|
-        next unless condition.instance_variable_get(var)
+    # Fail-closed allowlist: the exact wire fields each condition type serializes,
+    # in output order. Anything NOT listed here (e.g. the runtime-only @flag_name
+    # salt on percentage) is never written to the persisted blob. A new condition
+    # type, or a new wire field, must be added here deliberately; the default is to
+    # serialize nothing but the type. This is the opposite of the prior approach,
+    # which reflected over instance variables and wrote every truthy one with no
+    # exclusion list, leaking any runtime ivar the moment it existed.
+    CONDITION_WIRE_FIELDS = {
+      'always' => [],
+      'never' => [],
+      'list' => %i[values parameter],
+      'range' => %i[min max parameter],
+      'percentage' => %i[percentage parameter]
+    }.freeze
+    private_constant :CONDITION_WIRE_FIELDS
 
-        hash[var.to_s.delete('@')] = condition.instance_variable_get(var)
+    def condition_to_hash(condition)
+      type = condition.class.name.split('::').last.downcase
+      hash = { type: type }
+
+      CONDITION_WIRE_FIELDS.fetch(type, []).each do |field|
+        value = condition.public_send(field)
+        next if value.nil?
+
+        hash[field.to_s] = value
       end
 
       hash
@@ -108,6 +149,8 @@ module EightBall::Marshallers
 
       json_conditions.map do |condition|
         condition_class = EightBall::Conditions.by_name condition[:type]
+        raise UnknownConditionType, condition[:type].to_s if condition_class.nil?
+
         condition_class.new condition
       end
     end

--- a/lib/eight_ball/marshallers/json.rb
+++ b/lib/eight_ball/marshallers/json.rb
@@ -37,11 +37,6 @@ require 'plissken'
 #   }]
 module EightBall::Marshallers
   class Json
-    # Raised when a condition cannot be built; caught per-feature to fail that
-    # single flag closed (OFF).
-    UnknownConditionType = Class.new(StandardError)
-    private_constant :UnknownConditionType
-
     # Convert the given {EightBall::Feature Features} into a JSON array.
     #
     # @param [Array<EightBall::Feature>] features The {EightBall::Feature Features} to convert.
@@ -71,7 +66,7 @@ module EightBall::Marshallers
 
       raise ArgumentError, 'JSON input was not an array' unless parsed.is_a? Array
 
-      parsed.map do |feature|
+      parsed.filter_map do |feature|
         build_feature feature
       end
     rescue JSON::ParserError => e
@@ -82,67 +77,54 @@ module EightBall::Marshallers
     private
 
     def build_feature(feature)
+      unless feature.is_a?(Hash)
+        EightBall.logger.warn { "Skipping non-object feature entry: #{feature.inspect}" }
+        return nil
+      end
+
       enabled_for = create_conditions_from_json feature[:enabled_for]
       disabled_for = create_conditions_from_json feature[:disabled_for]
+      built = EightBall::Feature.new feature[:name], enabled_for, disabled_for, metadata: feature[:metadata]
 
-      EightBall::Feature.new feature[:name], enabled_for, disabled_for, metadata: feature[:metadata]
-    rescue UnknownConditionType, ArgumentError => e
-      EightBall.logger.warn { "Feature '#{feature[:name]}' has an invalid condition (#{e.message}); marking it un-evaluable (OFF)" }
-      # Keep the raw source so re-marshalling re-emits the flag unchanged.
-      EightBall::Feature.new(feature[:name], [], [], metadata: feature[:metadata]).tap { |f| f.un_evaluable! feature }
+      unparseable = (enabled_for + disabled_for).select { |condition| condition.is_a?(EightBall::Conditions::Opaque) }
+      unless unparseable.empty?
+        EightBall.logger.warn { "Feature #{feature[:name].inspect} has unparseable condition(s) #{unparseable.map(&:raw).inspect}; marking it un-evaluable (OFF)" }
+        built.un_evaluable!
+      end
+
+      built
     end
 
     def feature_to_hash(feature)
-      # Un-evaluable features re-emit their raw source unchanged.
-      return feature.source if feature.un_evaluable? && feature.source
-
       hash = {
         name: feature.name
       }
 
-      hash[:enabled_for] = feature.enabled_for.map { |condition| condition_to_hash(condition) } unless feature.enabled_for.empty?
-      hash[:disabled_for] = feature.disabled_for.map { |condition| condition_to_hash(condition) } unless feature.disabled_for.empty?
+      hash[:enabled_for] = feature.enabled_for.map(&:to_wire) unless feature.enabled_for.empty?
+      hash[:disabled_for] = feature.disabled_for.map(&:to_wire) unless feature.disabled_for.empty?
       hash[:metadata] = feature.metadata unless feature.metadata.nil?
 
       hash
     end
 
-    # Wire fields each condition type serializes, in output order. Anything not
-    # listed (e.g. percentage's runtime flag_name salt) is never persisted.
-    CONDITION_WIRE_FIELDS = {
-      'always' => [],
-      'never' => [],
-      'list' => %i[values parameter],
-      'range' => %i[min max parameter],
-      'percentage' => %i[percentage parameter]
-    }.freeze
-    private_constant :CONDITION_WIRE_FIELDS
+    def create_conditions_from_json(json_conditions)
+      return [] unless json_conditions.is_a?(Array)
 
-    def condition_to_hash(condition)
-      type = condition.class.name.split('::').last.downcase
-      hash = { type: type }
-
-      CONDITION_WIRE_FIELDS.fetch(type, []).each do |field|
-        value = condition.public_send(field)
-        next if value.nil?
-
-        hash[field.to_s] = value
-      end
-
-      hash
+      json_conditions.map { |condition| build_condition condition }
     end
 
-    def create_conditions_from_json(json_conditions)
-      return [] unless json_conditions&.is_a?(Array)
+    # Build one condition, or wrap anything unbuildable (non-object, unknown type,
+    # invalid params) in an Opaque condition so a single bad entry fails only its
+    # flag closed instead of aborting the whole parse.
+    def build_condition(condition)
+      return EightBall::Conditions::Opaque.new(condition) unless condition.is_a?(Hash)
 
-      json_conditions.map do |condition|
-        raise UnknownConditionType, "not a condition object: #{condition.class}" unless condition.is_a?(Hash)
+      condition_class = EightBall::Conditions.by_name condition[:type]
+      return EightBall::Conditions::Opaque.new(condition) if condition_class.nil?
 
-        condition_class = EightBall::Conditions.by_name condition[:type]
-        raise UnknownConditionType, condition[:type].to_s if condition_class.nil?
-
-        condition_class.new condition
-      end
+      condition_class.new condition
+    rescue ArgumentError
+      EightBall::Conditions::Opaque.new(condition)
     end
   end
 end

--- a/lib/eight_ball/marshallers/json.rb
+++ b/lib/eight_ball/marshallers/json.rb
@@ -37,9 +37,8 @@ require 'plissken'
 #   }]
 module EightBall::Marshallers
   class Json
-    # Raised internally by create_conditions_from_json when a Condition type is
-    # not recognized. Caught per-feature by unmarshall so a single bad Feature
-    # is failed closed (OFF) instead of taking down the whole feature set.
+    # Raised when a condition cannot be built; caught per-feature to fail that
+    # single flag closed (OFF).
     UnknownConditionType = Class.new(StandardError)
     private_constant :UnknownConditionType
 
@@ -88,19 +87,13 @@ module EightBall::Marshallers
 
       EightBall::Feature.new feature[:name], enabled_for, disabled_for, metadata: feature[:metadata]
     rescue UnknownConditionType, ArgumentError => e
-      # Fail ONLY this flag closed (OFF) for any unbuildable condition: an unknown
-      # type OR a known type with invalid params (e.g. a range missing min). Both
-      # would otherwise raise out of unmarshall and black out the whole blob.
       EightBall.logger.warn { "Feature '#{feature[:name]}' has an invalid condition (#{e.message}); marking it un-evaluable (OFF)" }
-      # Retain the raw source so re-marshalling re-emits the unparseable flag verbatim
-      # (keeps it fail-closed on the next read; never drops the definition).
+      # Keep the raw source so re-marshalling re-emits the flag unchanged.
       EightBall::Feature.new(feature[:name], [], [], metadata: feature[:metadata]).tap { |f| f.un_evaluable! feature }
     end
 
     def feature_to_hash(feature)
-      # An un-evaluable feature re-emits its original raw source verbatim, so a
-      # read -> marshall -> persist cycle neither drops the unparseable definition
-      # nor flips the flag from fail-closed OFF to fail-open ON.
+      # Un-evaluable features re-emit their raw source unchanged.
       return feature.source if feature.un_evaluable? && feature.source
 
       hash = {
@@ -114,13 +107,8 @@ module EightBall::Marshallers
       hash
     end
 
-    # Fail-closed allowlist: the exact wire fields each condition type serializes,
-    # in output order. Anything NOT listed here (e.g. the runtime-only @flag_name
-    # salt on percentage) is never written to the persisted blob. A new condition
-    # type, or a new wire field, must be added here deliberately; the default is to
-    # serialize nothing but the type. This is the opposite of the prior approach,
-    # which reflected over instance variables and wrote every truthy one with no
-    # exclusion list, leaking any runtime ivar the moment it existed.
+    # Wire fields each condition type serializes, in output order. Anything not
+    # listed (e.g. percentage's runtime flag_name salt) is never persisted.
     CONDITION_WIRE_FIELDS = {
       'always' => [],
       'never' => [],

--- a/lib/eight_ball/marshallers/json.rb
+++ b/lib/eight_ball/marshallers/json.rb
@@ -148,6 +148,8 @@ module EightBall::Marshallers
       return [] unless json_conditions&.is_a?(Array)
 
       json_conditions.map do |condition|
+        raise UnknownConditionType, "not a condition object: #{condition.class}" unless condition.is_a?(Hash)
+
         condition_class = EightBall::Conditions.by_name condition[:type]
         raise UnknownConditionType, condition[:type].to_s if condition_class.nil?
 

--- a/lib/eight_ball/marshallers/json.rb
+++ b/lib/eight_ball/marshallers/json.rb
@@ -87,7 +87,12 @@ module EightBall::Marshallers
       built = EightBall::Feature.new feature[:name], enabled_for, disabled_for, metadata: feature[:metadata]
 
       unparseable = (enabled_for + disabled_for).select { |condition| condition.is_a?(EightBall::Conditions::Opaque) }
-      unless unparseable.empty?
+
+      # A nameless flag can't be looked up, and its flag-name-salted conditions raise at eval; fail it closed.
+      if feature[:name].nil?
+        EightBall.logger.warn { 'Feature entry has no name; marking it un-evaluable (OFF)' }
+        built.un_evaluable!
+      elsif !unparseable.empty?
         EightBall.logger.warn { "Feature #{feature[:name].inspect} has unparseable condition(s) #{unparseable.map(&:raw).inspect}; marking it un-evaluable (OFF)" }
         built.un_evaluable!
       end

--- a/lib/eight_ball/marshallers/json.rb
+++ b/lib/eight_ball/marshallers/json.rb
@@ -70,7 +70,7 @@ module EightBall::Marshallers
         build_feature feature
       end
     rescue JSON::ParserError => e
-      EightBall.logger.error { "Failed to parse JSON: #{e.message}" }
+      EightBall.logger.error { "Failed to parse JSON: #{e.message.inspect}" }
       []
     end
 
@@ -108,7 +108,8 @@ module EightBall::Marshallers
     end
 
     def create_conditions_from_json(json_conditions)
-      return [] unless json_conditions.is_a?(Array)
+      return [] if json_conditions.nil?
+      return [EightBall::Conditions::Opaque.new(json_conditions)] unless json_conditions.is_a?(Array)
 
       json_conditions.map { |condition| build_condition condition }
     end
@@ -123,7 +124,7 @@ module EightBall::Marshallers
       return EightBall::Conditions::Opaque.new(condition) if condition_class.nil?
 
       condition_class.new condition
-    rescue ArgumentError
+    rescue StandardError
       EightBall::Conditions::Opaque.new(condition)
     end
   end

--- a/lib/eight_ball/version.rb
+++ b/lib/eight_ball/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EightBall
-  VERSION = '3.2.0'
+  VERSION = '3.3.0'
 end

--- a/spec/conditions/conditions_spec.rb
+++ b/spec/conditions/conditions_spec.rb
@@ -8,5 +8,11 @@ RSpec.describe EightBall::Conditions do
       expect(EightBall::Conditions.by_name('Always')).to eq EightBall::Conditions::Always
       expect(EightBall::Conditions.by_name('aLwAyS')).to eq EightBall::Conditions::Always
     end
+
+    it 'should resolve percentage case-insensitively' do
+      expect(EightBall::Conditions.by_name('percentage')).to eq EightBall::Conditions::Percentage
+      expect(EightBall::Conditions.by_name('Percentage')).to eq EightBall::Conditions::Percentage
+      expect(EightBall::Conditions.by_name('PERCENTAGE')).to eq EightBall::Conditions::Percentage
+    end
   end
 end

--- a/spec/conditions/opaque_spec.rb
+++ b/spec/conditions/opaque_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe EightBall::Conditions::Opaque do
+  let(:raw) { { type: 'made_up', parameter: 'account_id' } }
+
+  it 'is never satisfied' do
+    expect(EightBall::Conditions::Opaque.new(raw).satisfied?('anything')).to be false
+    expect(EightBall::Conditions::Opaque.new(raw).satisfied?).to be false
+  end
+
+  it 're-emits its raw input verbatim' do
+    expect(EightBall::Conditions::Opaque.new(raw).to_wire).to eq raw
+  end
+
+  it 'is equal when wrapping equal raw input' do
+    expect(EightBall::Conditions::Opaque.new(raw)).to eq EightBall::Conditions::Opaque.new(raw.dup)
+    expect(EightBall::Conditions::Opaque.new(raw)).not_to eq EightBall::Conditions::Opaque.new(type: 'other')
+  end
+end

--- a/spec/conditions/percentage_distribution_spec.rb
+++ b/spec/conditions/percentage_distribution_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Percentage condition distribution' do
+  let(:ids) { (0...10_000).map { |i| "org-#{i}" } }
+
+  def feature_for(percentage)
+    condition = EightBall::Conditions::Percentage.new percentage: percentage, parameter: 'organization_id'
+    EightBall::Feature.new 'DistFlag', [condition]
+  end
+
+  it 'should land within +/- 3 points of the configured percentage' do
+    [10, 25, 50, 75, 90].each do |target|
+      feature = feature_for(target)
+      hits = ids.count { |id| feature.enabled?(organization_id: id) }
+      observed = (hits.to_f / ids.size) * 100
+
+      expect(observed).to be_within(3).of(target),
+        "percentage #{target}: observed #{observed.round(2)}% (#{hits}/#{ids.size})"
+    end
+  end
+
+  it 'should be perfectly sticky across two independent evaluation passes' do
+    feature = feature_for(50)
+    pass_one = ids.map { |id| feature.enabled?(organization_id: id) }
+    pass_two = ids.map { |id| feature.enabled?(organization_id: id) }
+
+    expect(pass_two).to eq pass_one
+  end
+end

--- a/spec/conditions/percentage_distribution_spec.rb
+++ b/spec/conditions/percentage_distribution_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Percentage condition distribution' do
-  let(:ids) { (0...10_000).map { |i| "org-#{i}" } }
+  let(:ids) { (0...10_000).map { |i| "acct-#{i}" } }
 
   def feature_for(percentage)
-    condition = EightBall::Conditions::Percentage.new percentage: percentage, parameter: 'organization_id'
+    condition = EightBall::Conditions::Percentage.new percentage: percentage, parameter: 'account_id'
     EightBall::Feature.new 'DistFlag', [condition]
   end
 
   it 'should land within +/- 3 points of the configured percentage' do
     [10, 25, 50, 75, 90].each do |target|
       feature = feature_for(target)
-      hits = ids.count { |id| feature.enabled?(organization_id: id) }
+      hits = ids.count { |id| feature.enabled?(account_id: id) }
       observed = (hits.to_f / ids.size) * 100
 
       expect(observed).to be_within(3).of(target),
@@ -21,8 +21,8 @@ RSpec.describe 'Percentage condition distribution' do
 
   it 'should be perfectly sticky across two independent evaluation passes' do
     feature = feature_for(50)
-    pass_one = ids.map { |id| feature.enabled?(organization_id: id) }
-    pass_two = ids.map { |id| feature.enabled?(organization_id: id) }
+    pass_one = ids.map { |id| feature.enabled?(account_id: id) }
+    pass_two = ids.map { |id| feature.enabled?(account_id: id) }
 
     expect(pass_two).to eq pass_one
   end

--- a/spec/conditions/percentage_spec.rb
+++ b/spec/conditions/percentage_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'digest'
+
+RSpec.describe EightBall::Conditions::Percentage do
+  def build(percentage:, flag_name: 'Flag', parameter: nil)
+    opts = { percentage: percentage }
+    opts[:parameter] = parameter if parameter
+    condition = EightBall::Conditions::Percentage.new opts
+    condition.flag_name = flag_name
+    condition
+  end
+
+  describe 'initialize' do
+    it 'should raise if percentage is missing' do
+      expect { EightBall::Conditions::Percentage.new(parameter: 'organization_id') }
+        .to raise_error ArgumentError, 'Missing value for percentage'
+    end
+
+    it 'should raise if percentage is out of range' do
+      expect { EightBall::Conditions::Percentage.new(percentage: -1) }
+        .to raise_error ArgumentError, 'percentage must be an integer between 0 and 100'
+      expect { EightBall::Conditions::Percentage.new(percentage: 101) }
+        .to raise_error ArgumentError, 'percentage must be an integer between 0 and 100'
+      expect { EightBall::Conditions::Percentage.new(percentage: 'fifty') }
+        .to raise_error ArgumentError, 'percentage must be an integer between 0 and 100'
+    end
+
+    it 'should default parameter to organization_id' do
+      expect(EightBall::Conditions::Percentage.new(percentage: 50).parameter).to eq 'organization_id'
+    end
+
+    it 'should accept an explicit parameter (snake-cased by Base)' do
+      expect(EightBall::Conditions::Percentage.new(percentage: 50, parameter: 'accountId').parameter).to eq 'account_id'
+    end
+
+    it 'should expose the percentage' do
+      expect(EightBall::Conditions::Percentage.new(percentage: 25).percentage).to eq 25
+    end
+  end
+
+  describe 'satisfied?' do
+    it 'should raise if flag_name was never injected' do
+      condition = EightBall::Conditions::Percentage.new percentage: 50
+      expect { condition.satisfied?('123') }
+        .to raise_error ArgumentError, 'flag_name has not been set on Percentage condition'
+    end
+
+    it 'should match the canonical bucket formula exactly' do
+      condition = build(percentage: 100, flag_name: 'MyFlag')
+      value = 'org-42'
+
+      expected_bucket = Integer(Digest::SHA256.hexdigest("MyFlag:#{value}")[0, 8], 16) % 100
+      # percentage 100 => always satisfied; assert the bucket math is the documented one.
+      expect(expected_bucket).to be_between(0, 99)
+      expect(condition.satisfied?(value)).to be true
+    end
+
+    it 'should be satisfied iff bucket < percentage' do
+      flag = 'BucketFlag'
+      value = 'org-7'
+      bucket = Integer(Digest::SHA256.hexdigest("#{flag}:#{value}")[0, 8], 16) % 100
+
+      # Just below the bucket => not satisfied; just above => satisfied.
+      expect(build(percentage: bucket, flag_name: flag).satisfied?(value)).to be false
+      expect(build(percentage: bucket + 1, flag_name: flag).satisfied?(value)).to be true
+    end
+
+    it 'should never be satisfied at percentage 0' do
+      condition = build(percentage: 0, flag_name: 'Z')
+      20.times { |i| expect(condition.satisfied?("id-#{i}")).to be false }
+    end
+
+    it 'should always be satisfied at percentage 100' do
+      condition = build(percentage: 100, flag_name: 'Z')
+      20.times { |i| expect(condition.satisfied?("id-#{i}")).to be true }
+    end
+
+    it 'should be deterministic (sticky) for the same flag + value' do
+      condition = build(percentage: 50, flag_name: 'StickyFlag')
+      first = condition.satisfied?('org-99')
+      10.times { expect(condition.satisfied?('org-99')).to eq first }
+    end
+
+    it 'should coerce the value to a string so 42 and "42" bucket identically' do
+      int_bucket = Integer(Digest::SHA256.hexdigest('F:42')[0, 8], 16) % 100
+      expect(int_bucket).to be_between(0, 99)
+
+      # Assert at a threshold that straddles the shared bucket, so the outcome depends
+      # on the actual bucket: a stringification regression (42 vs "42" bucketing
+      # differently) would make the integer and string subjects diverge here.
+      expect(build(percentage: int_bucket, flag_name: 'F').satisfied?(42)).to be false
+      expect(build(percentage: int_bucket, flag_name: 'F').satisfied?('42')).to be false
+      expect(build(percentage: int_bucket + 1, flag_name: 'F').satisfied?(42)).to be true
+      expect(build(percentage: int_bucket + 1, flag_name: 'F').satisfied?('42')).to be true
+    end
+
+    it 'should decorrelate an id across different flags (flag name is the salt)' do
+      value = 'org-123'
+      buckets = %w[FlagA FlagB FlagC].to_h do |flag|
+        [flag, Integer(Digest::SHA256.hexdigest("#{flag}:#{value}")[0, 8], 16) % 100]
+      end
+      # The three fixed names do not all bucket the same value identically.
+      expect(buckets.values.uniq.size).to be > 1
+
+      # Prove the REAL condition uses the flag name as salt: each flag's verdict tracks
+      # ITS OWN bucket. A bug that ignored flag_name would bucket every flag identically
+      # and break these per-flag thresholds.
+      buckets.each do |flag, bucket|
+        expect(build(percentage: bucket, flag_name: flag).satisfied?(value)).to be false
+        expect(build(percentage: bucket + 1, flag_name: flag).satisfied?(value)).to be true
+      end
+    end
+  end
+
+  describe '==' do
+    it 'should be equal for same parameter and percentage' do
+      c1 = EightBall::Conditions::Percentage.new percentage: 30, parameter: 'organization_id'
+      c2 = EightBall::Conditions::Percentage.new percentage: 30, parameter: 'organization_id'
+      expect(c1 == c2).to be true
+    end
+
+    it 'should differ when percentage differs' do
+      c1 = EightBall::Conditions::Percentage.new percentage: 30
+      c2 = EightBall::Conditions::Percentage.new percentage: 40
+      expect(c1 == c2).to be false
+    end
+
+    it 'should differ when parameter differs' do
+      c1 = EightBall::Conditions::Percentage.new percentage: 30, parameter: 'organization_id'
+      c2 = EightBall::Conditions::Percentage.new percentage: 30, parameter: 'account_id'
+      expect(c1 == c2).to be false
+    end
+  end
+end

--- a/spec/conditions/percentage_spec.rb
+++ b/spec/conditions/percentage_spec.rb
@@ -86,9 +86,8 @@ RSpec.describe EightBall::Conditions::Percentage do
       int_bucket = Integer(Digest::SHA256.hexdigest('F:42')[0, 8], 16) % 100
       expect(int_bucket).to be_between(0, 99)
 
-      # Assert at a threshold that straddles the shared bucket, so the outcome depends
-      # on the actual bucket: a stringification regression (42 vs "42" bucketing
-      # differently) would make the integer and string subjects diverge here.
+      # At a threshold straddling the shared bucket, int and string subjects must
+      # agree; a coercion regression would diverge here.
       expect(build(percentage: int_bucket, flag_name: 'F').satisfied?(42)).to be false
       expect(build(percentage: int_bucket, flag_name: 'F').satisfied?('42')).to be false
       expect(build(percentage: int_bucket + 1, flag_name: 'F').satisfied?(42)).to be true
@@ -103,9 +102,8 @@ RSpec.describe EightBall::Conditions::Percentage do
       # The three fixed names do not all bucket the same value identically.
       expect(buckets.values.uniq.size).to be > 1
 
-      # Prove the REAL condition uses the flag name as salt: each flag's verdict tracks
-      # ITS OWN bucket. A bug that ignored flag_name would bucket every flag identically
-      # and break these per-flag thresholds.
+      # Each flag's verdict must track its own salted bucket; a flag_name-agnostic
+      # bug would fail here.
       buckets.each do |flag, bucket|
         expect(build(percentage: bucket, flag_name: flag).satisfied?(value)).to be false
         expect(build(percentage: bucket + 1, flag_name: flag).satisfied?(value)).to be true

--- a/spec/conditions/percentage_spec.rb
+++ b/spec/conditions/percentage_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe EightBall::Conditions::Percentage do
     it 'should expose the percentage' do
       expect(EightBall::Conditions::Percentage.new(percentage: 25).percentage).to eq 25
     end
+
+    it 'should accept an integral Float percentage' do
+      expect(EightBall::Conditions::Percentage.new(percentage: 50.0).percentage).to eq 50
+    end
+
+    it 'should reject a non-integral Float percentage' do
+      expect { EightBall::Conditions::Percentage.new(percentage: 50.5) }
+        .to raise_error ArgumentError, 'percentage must be an integer between 0 and 100'
+    end
   end
 
   describe 'satisfied?' do

--- a/spec/conditions/percentage_spec.rb
+++ b/spec/conditions/percentage_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe EightBall::Conditions::Percentage do
 
   describe 'initialize' do
     it 'should raise if percentage is missing' do
-      expect { EightBall::Conditions::Percentage.new(parameter: 'organization_id') }
+      expect { EightBall::Conditions::Percentage.new(parameter: 'account_id') }
         .to raise_error ArgumentError, 'Missing value for percentage'
     end
 
@@ -26,8 +26,8 @@ RSpec.describe EightBall::Conditions::Percentage do
         .to raise_error ArgumentError, 'percentage must be an integer between 0 and 100'
     end
 
-    it 'should default parameter to organization_id' do
-      expect(EightBall::Conditions::Percentage.new(percentage: 50).parameter).to eq 'organization_id'
+    it 'should leave parameter nil when not provided' do
+      expect(EightBall::Conditions::Percentage.new(percentage: 50).parameter).to be_nil
     end
 
     it 'should accept an explicit parameter (snake-cased by Base)' do
@@ -48,7 +48,7 @@ RSpec.describe EightBall::Conditions::Percentage do
 
     it 'should match the canonical bucket formula exactly' do
       condition = build(percentage: 100, flag_name: 'MyFlag')
-      value = 'org-42'
+      value = 'acct-42'
 
       expected_bucket = Integer(Digest::SHA256.hexdigest("MyFlag:#{value}")[0, 8], 16) % 100
       # percentage 100 => always satisfied; assert the bucket math is the documented one.
@@ -58,7 +58,7 @@ RSpec.describe EightBall::Conditions::Percentage do
 
     it 'should be satisfied iff bucket < percentage' do
       flag = 'BucketFlag'
-      value = 'org-7'
+      value = 'acct-7'
       bucket = Integer(Digest::SHA256.hexdigest("#{flag}:#{value}")[0, 8], 16) % 100
 
       # Just below the bucket => not satisfied; just above => satisfied.
@@ -78,8 +78,8 @@ RSpec.describe EightBall::Conditions::Percentage do
 
     it 'should be deterministic (sticky) for the same flag + value' do
       condition = build(percentage: 50, flag_name: 'StickyFlag')
-      first = condition.satisfied?('org-99')
-      10.times { expect(condition.satisfied?('org-99')).to eq first }
+      first = condition.satisfied?('acct-99')
+      10.times { expect(condition.satisfied?('acct-99')).to eq first }
     end
 
     it 'should coerce the value to a string so 42 and "42" bucket identically' do
@@ -96,7 +96,7 @@ RSpec.describe EightBall::Conditions::Percentage do
     end
 
     it 'should decorrelate an id across different flags (flag name is the salt)' do
-      value = 'org-123'
+      value = 'acct-123'
       buckets = %w[FlagA FlagB FlagC].to_h do |flag|
         [flag, Integer(Digest::SHA256.hexdigest("#{flag}:#{value}")[0, 8], 16) % 100]
       end
@@ -115,8 +115,8 @@ RSpec.describe EightBall::Conditions::Percentage do
 
   describe '==' do
     it 'should be equal for same parameter and percentage' do
-      c1 = EightBall::Conditions::Percentage.new percentage: 30, parameter: 'organization_id'
-      c2 = EightBall::Conditions::Percentage.new percentage: 30, parameter: 'organization_id'
+      c1 = EightBall::Conditions::Percentage.new percentage: 30, parameter: 'account_id'
+      c2 = EightBall::Conditions::Percentage.new percentage: 30, parameter: 'account_id'
       expect(c1 == c2).to be true
     end
 
@@ -127,8 +127,8 @@ RSpec.describe EightBall::Conditions::Percentage do
     end
 
     it 'should differ when parameter differs' do
-      c1 = EightBall::Conditions::Percentage.new percentage: 30, parameter: 'organization_id'
-      c2 = EightBall::Conditions::Percentage.new percentage: 30, parameter: 'account_id'
+      c1 = EightBall::Conditions::Percentage.new percentage: 30, parameter: 'account_id'
+      c2 = EightBall::Conditions::Percentage.new percentage: 30, parameter: 'region_name'
       expect(c1 == c2).to be false
     end
   end

--- a/spec/feature_spec.rb
+++ b/spec/feature_spec.rb
@@ -170,6 +170,12 @@ RSpec.describe EightBall::Feature do
       feature = EightBall::Feature.new 'WithMeta', [], [], metadata: meta
       expect(feature.enabled?).to be true
     end
+
+    it 'should distinguish two features that differ only in metadata' do
+      a = EightBall::Feature.new('Same', [EightBall::Conditions::Always.new], [], metadata: { 'type' => 'experiment' })
+      b = EightBall::Feature.new('Same', [EightBall::Conditions::Always.new], [], metadata: { 'type' => 'ops' })
+      expect(a == b).to be false
+    end
   end
 
   describe 'un_evaluable!' do

--- a/spec/feature_spec.rb
+++ b/spec/feature_spec.rb
@@ -152,4 +152,80 @@ RSpec.describe EightBall::Feature do
       expect(f1 == f2).to be false
     end
   end
+
+  describe 'metadata' do
+    it 'should default to nil when not provided' do
+      feature = EightBall::Feature.new 'NoMeta'
+      expect(feature.metadata).to be_nil
+    end
+
+    it 'should expose the metadata hash when provided' do
+      meta = { 'type' => 'experiment', 'owner' => 'growth', 'expires_at' => '2026-12-31' }
+      feature = EightBall::Feature.new 'WithMeta', [], [], metadata: meta
+      expect(feature.metadata).to eq meta
+    end
+
+    it 'should not affect evaluation' do
+      meta = { 'type' => 'experiment' }
+      feature = EightBall::Feature.new 'WithMeta', [], [], metadata: meta
+      expect(feature.enabled?).to be true
+    end
+  end
+
+  describe 'un_evaluable!' do
+    it 'should default to evaluable' do
+      feature = EightBall::Feature.new 'Feature', [EightBall::Conditions::Always.new]
+      expect(feature.un_evaluable?).to be false
+      expect(feature.enabled?).to be true
+    end
+
+    it 'should force enabled? to false once marked, regardless of conditions' do
+      feature = EightBall::Feature.new 'Feature', [EightBall::Conditions::Always.new]
+      feature.un_evaluable!
+
+      expect(feature.un_evaluable?).to be true
+      expect(feature.enabled?).to be false
+    end
+
+    it 'should not raise for missing parameters when un-evaluable' do
+      condition = EightBall::Conditions::List.new parameter: 'param1', values: [1, 2]
+      feature = EightBall::Feature.new 'Feature', condition
+      feature.un_evaluable!
+
+      # Normally this raises ArgumentError (missing param1); un-evaluable must short-circuit first.
+      expect(feature.enabled?).to be false
+    end
+  end
+
+  describe 'percentage condition integration' do
+    it 'should inject the flag name as the bucket salt at construction' do
+      condition = EightBall::Conditions::Percentage.new percentage: 50, parameter: 'organization_id'
+      EightBall::Feature.new 'SaltedFlag', [condition]
+
+      expect(condition.flag_name).to eq 'SaltedFlag'
+    end
+
+    it 'should evaluate a percentage condition end-to-end without raising' do
+      condition = EightBall::Conditions::Percentage.new percentage: 100, parameter: 'organization_id'
+      feature = EightBall::Feature.new 'Exp', [condition]
+
+      # percentage 100 => always on; the key assertion is that flag_name was
+      # injected so satisfied? does not raise the "flag_name has not been set" error.
+      expect(feature.enabled?(organization_id: 'org-1')).to be true
+    end
+
+    it 'should give the same verdict for the same org across repeated evaluations (sticky)' do
+      condition = EightBall::Conditions::Percentage.new percentage: 50, parameter: 'organization_id'
+      feature = EightBall::Feature.new 'Sticky', [condition]
+
+      first = feature.enabled?(organization_id: 'org-77')
+      5.times { expect(feature.enabled?(organization_id: 'org-77')).to eq first }
+    end
+
+    it 'should not inject flag_name into legacy conditions' do
+      list = EightBall::Conditions::List.new values: [1, 2], parameter: 'account_id'
+      expect { EightBall::Feature.new 'Legacy', [list] }.not_to raise_error
+      expect(list).not_to respond_to(:flag_name)
+    end
+  end
 end

--- a/spec/feature_spec.rb
+++ b/spec/feature_spec.rb
@@ -199,27 +199,27 @@ RSpec.describe EightBall::Feature do
 
   describe 'percentage condition integration' do
     it 'should inject the flag name as the bucket salt at construction' do
-      condition = EightBall::Conditions::Percentage.new percentage: 50, parameter: 'organization_id'
+      condition = EightBall::Conditions::Percentage.new percentage: 50, parameter: 'account_id'
       EightBall::Feature.new 'SaltedFlag', [condition]
 
       expect(condition.flag_name).to eq 'SaltedFlag'
     end
 
     it 'should evaluate a percentage condition end-to-end without raising' do
-      condition = EightBall::Conditions::Percentage.new percentage: 100, parameter: 'organization_id'
+      condition = EightBall::Conditions::Percentage.new percentage: 100, parameter: 'account_id'
       feature = EightBall::Feature.new 'Exp', [condition]
 
       # percentage 100 => always on; the key assertion is that flag_name was
       # injected so satisfied? does not raise the "flag_name has not been set" error.
-      expect(feature.enabled?(organization_id: 'org-1')).to be true
+      expect(feature.enabled?(account_id: 'acct-1')).to be true
     end
 
-    it 'should give the same verdict for the same org across repeated evaluations (sticky)' do
-      condition = EightBall::Conditions::Percentage.new percentage: 50, parameter: 'organization_id'
+    it 'should give the same verdict for the same subject across repeated evaluations (sticky)' do
+      condition = EightBall::Conditions::Percentage.new percentage: 50, parameter: 'account_id'
       feature = EightBall::Feature.new 'Sticky', [condition]
 
-      first = feature.enabled?(organization_id: 'org-77')
-      5.times { expect(feature.enabled?(organization_id: 'org-77')).to eq first }
+      first = feature.enabled?(account_id: 'acct-77')
+      5.times { expect(feature.enabled?(account_id: 'acct-77')).to eq first }
     end
 
     it 'should not inject flag_name into legacy conditions' do

--- a/spec/feature_spec.rb
+++ b/spec/feature_spec.rb
@@ -200,9 +200,20 @@ RSpec.describe EightBall::Feature do
   describe 'percentage condition integration' do
     it 'should inject the flag name as the bucket salt at construction' do
       condition = EightBall::Conditions::Percentage.new percentage: 50, parameter: 'account_id'
-      EightBall::Feature.new 'SaltedFlag', [condition]
+      feature = EightBall::Feature.new 'SaltedFlag', [condition]
 
-      expect(condition.flag_name).to eq 'SaltedFlag'
+      expect(feature.enabled_for.first.flag_name).to eq 'SaltedFlag'
+      expect(condition.flag_name).to be_nil
+    end
+
+    it 'should not re-salt a condition shared across features (duped on inject)' do
+      shared = EightBall::Conditions::Percentage.new percentage: 50, parameter: 'account_id'
+      f1 = EightBall::Feature.new 'FlagOne', [shared]
+      f2 = EightBall::Feature.new 'FlagTwo', [shared]
+
+      expect(f1.enabled_for.first.flag_name).to eq 'FlagOne'
+      expect(f2.enabled_for.first.flag_name).to eq 'FlagTwo'
+      expect(shared.flag_name).to be_nil
     end
 
     it 'should evaluate a percentage condition end-to-end without raising' do

--- a/spec/feature_spec.rb
+++ b/spec/feature_spec.rb
@@ -216,6 +216,20 @@ RSpec.describe EightBall::Feature do
       expect(shared.flag_name).to be_nil
     end
 
+    it 'does not require the conditions array to be unfrozen' do
+      conditions = [EightBall::Conditions::Always.new].freeze
+      expect { EightBall::Feature.new('Frozen', conditions) }.not_to raise_error
+    end
+
+    it 'does not mutate the caller conditions array' do
+      pct = EightBall::Conditions::Percentage.new percentage: 50, parameter: 'account_id'
+      arr = [pct]
+      EightBall::Feature.new 'X', arr
+
+      expect(arr.first).to be pct
+      expect(arr.first.flag_name).to be_nil
+    end
+
     it 'should evaluate a percentage condition end-to-end without raising' do
       condition = EightBall::Conditions::Percentage.new percentage: 100, parameter: 'account_id'
       feature = EightBall::Feature.new 'Exp', [condition]

--- a/spec/feature_spec.rb
+++ b/spec/feature_spec.rb
@@ -258,5 +258,15 @@ RSpec.describe EightBall::Feature do
       expect { EightBall::Feature.new 'Legacy', [list] }.not_to raise_error
       expect(list).not_to respond_to(:flag_name)
     end
+
+    it 'should inject the flag name into disabled_for conditions too' do
+      condition = EightBall::Conditions::Percentage.new percentage: 100, parameter: 'account_id'
+      feature = EightBall::Feature.new 'DisabledPct', [], [condition]
+
+      expect(feature.disabled_for.first.flag_name).to eq 'DisabledPct'
+      # percentage 100 in disabled_for => always disabled; must evaluate without
+      # raising, proving the salt is injected on the disabled_for path too.
+      expect(feature.enabled?(account_id: 'acct-1')).to be false
+    end
   end
 end

--- a/spec/marshallers/json_spec.rb
+++ b/spec/marshallers/json_spec.rb
@@ -368,5 +368,30 @@ RSpec.describe EightBall::Marshallers::Json do
       expect(features.first.un_evaluable?).to be true
       expect(features.first.enabled?).to be false
     end
+
+    it 'should fail a nameless flag closed instead of raising at eval' do
+      # No name means a nil salt is injected into the percentage condition, which would
+      # raise at eval; it must fail closed like any other unparseable flag.
+      json = %([{ "enabledFor": [{ "type": "percentage", "parameter": "accountId", "percentage": 100 }] }])
+
+      features = marshaller.unmarshall(json)
+
+      expect(features.size).to be 1
+      expect(features.first.un_evaluable?).to be true
+      expect { features.first.enabled?(account_id: 'acct-1') }.not_to raise_error
+      expect(features.first.enabled?(account_id: 'acct-1')).to be false
+    end
+
+    it 'should inject flag_name for a percentage condition in disabledFor' do
+      json = %([{ "name": "DisabledPct", "disabledFor": [{ "type": "percentage", "parameter": "accountId", "percentage": 100 }] }])
+
+      features = marshaller.unmarshall(json)
+      condition = features[0].disabled_for[0]
+
+      expect(condition).to be_a EightBall::Conditions::Percentage
+      expect(condition.flag_name).to eq 'DisabledPct'
+      # Must evaluate without raising: the salt is injected through the marshaller path.
+      expect(features[0].enabled?(account_id: 'acct-1')).to be false
+    end
   end
 end

--- a/spec/marshallers/json_spec.rb
+++ b/spec/marshallers/json_spec.rb
@@ -343,5 +343,30 @@ RSpec.describe EightBall::Marshallers::Json do
       expect(features.map(&:name)).to eq ['Good']
       expect(features.first.enabled?).to be true
     end
+
+    it 'should fail a flag closed when a condition list is present but not an array' do
+      json = %(
+        [{ "name": "Good", "enabledFor": [{ "type": "always" }] },
+         { "name": "BadEnabledList", "enabledFor": { "type": "always" } },
+         { "name": "BadDisabledList", "disabledFor": "nope" }]
+      )
+
+      features = nil
+      expect { features = marshaller.unmarshall(json) }.not_to raise_error
+
+      expect(features.find { |f| f.name == 'Good' }.enabled?).to be true
+      expect(features.find { |f| f.name == 'BadEnabledList' }.enabled?).to be false
+      expect(features.find { |f| f.name == 'BadDisabledList' }.enabled?).to be false
+    end
+
+    it 'should fail a flag closed when a condition constructor raises a non-ArgumentError' do
+      # array bounds hit [2] < [1] -> NoMethodError inside Range#initialize
+      json = %([{ "name": "BadRange", "enabledFor": [{ "type": "range", "min": [1], "max": [2] }] }])
+
+      features = nil
+      expect { features = marshaller.unmarshall(json) }.not_to raise_error
+      expect(features.first.un_evaluable?).to be true
+      expect(features.first.enabled?).to be false
+    end
   end
 end

--- a/spec/marshallers/json_spec.rb
+++ b/spec/marshallers/json_spec.rb
@@ -47,6 +47,64 @@ RSpec.describe EightBall::Marshallers::Json do
 
       expect(marshaller.marshall(features)).to eq json
     end
+
+    it 'should include top-level metadata when present' do
+      features = [
+        EightBall::Feature.new(
+          'WithMeta',
+          [EightBall::Conditions::Always.new],
+          [],
+          metadata: { 'type' => 'experiment', 'owner' => 'growth', 'expires_at' => '2026-12-31' }
+        )
+      ]
+
+      json = '[{"name":"WithMeta","enabledFor":[{"type":"always"}],"metadata":{"type":"experiment","owner":"growth","expiresAt":"2026-12-31"}}]'
+
+      expect(marshaller.marshall(features)).to eq json
+    end
+
+    it 'should omit metadata key when nil' do
+      features = [EightBall::Feature.new('NoMeta', [EightBall::Conditions::Always.new])]
+
+      json = '[{"name":"NoMeta","enabledFor":[{"type":"always"}]}]'
+
+      expect(marshaller.marshall(features)).to eq json
+    end
+
+    it 'should marshall a percentage condition without leaking flag_name (fail-closed allowlist)' do
+      condition = EightBall::Conditions::Percentage.new(percentage: 25, parameter: 'organization_id')
+      condition.flag_name = 'Experiment' # runtime injection; must NEVER appear in JSON
+
+      features = [EightBall::Feature.new('Experiment', [condition])]
+
+      # parameter serializes snake_case: Base#parameter= snake-cases on construction and
+      # to_camelback_keys only transforms keys, not values (matches the canonical wire contract).
+      json = '[{"name":"Experiment","enabledFor":[{"type":"percentage","percentage":25,"parameter":"organization_id"}]}]'
+
+      result = marshaller.marshall(features)
+      expect(result).to eq json
+      # The allowlist guarantees the runtime salt is never serialized, by construction.
+      expect(result).not_to include 'flagName'
+      expect(result).not_to include 'flag_name'
+    end
+
+    it 'should round-trip every condition type through the allowlist unchanged' do
+      features = [
+        EightBall::Feature.new('AlwaysFlag', [EightBall::Conditions::Always.new]),
+        EightBall::Feature.new('NeverFlag', [EightBall::Conditions::Never.new]),
+        EightBall::Feature.new('ListFlag', [EightBall::Conditions::List.new(values: [1, 2, 3], parameter: 'param1')]),
+        EightBall::Feature.new('RangeFlag', [EightBall::Conditions::Range.new(min: 1, max: 5, parameter: 'accountId')]),
+        EightBall::Feature.new('PctFlag', [EightBall::Conditions::Percentage.new(percentage: 30, parameter: 'organizationId')])
+      ]
+
+      json = marshaller.marshall(features)
+
+      expect(json).to include '{"type":"always"}'
+      expect(json).to include '{"type":"never"}'
+      expect(json).to include '{"type":"list","values":[1,2,3],"parameter":"param1"}'
+      expect(json).to include '{"type":"range","min":1,"max":5,"parameter":"account_id"}'
+      expect(json).to include '{"type":"percentage","percentage":30,"parameter":"organization_id"}'
+    end
   end
 
   describe 'unmarshall' do
@@ -100,6 +158,138 @@ RSpec.describe EightBall::Marshallers::Json do
       features = marshaller.unmarshall ''
 
       expect(features).to eq []
+    end
+
+    it 'should round-trip metadata through unmarshall and marshall' do
+      json = %(
+        [{
+          "name": "WithMeta",
+          "enabledFor": [{ "type": "always" }],
+          "metadata": { "type": "experiment", "owner": "growth", "expiresAt": "2026-12-31" }
+        }]
+      )
+
+      features = marshaller.unmarshall json
+
+      expect(features.size).to be 1
+      # Keys are symbols: unmarshall parses with symbolize_names, so metadata
+      # (like every other unmarshalled hash) comes back symbol-keyed and snake-cased.
+      expect(features[0].metadata).to eq(
+        type: 'experiment', owner: 'growth', expires_at: '2026-12-31'
+      )
+
+      # Round-trip: marshalling what we unmarshalled reproduces the camelCase wire form.
+      expect(marshaller.marshall(features)).to eq(
+        '[{"name":"WithMeta","enabledFor":[{"type":"always"}],"metadata":{"type":"experiment","owner":"growth","expiresAt":"2026-12-31"}}]'
+      )
+    end
+
+    it 'should leave metadata nil when absent' do
+      json = %([{ "name": "NoMeta" }])
+
+      features = marshaller.unmarshall json
+
+      expect(features[0].metadata).to be_nil
+    end
+
+    it 'should mark only the offending feature un-evaluable on unknown condition type, not raise' do
+      json = %(
+        [{
+          "name": "GoodFlag",
+          "enabledFor": [{ "type": "always" }]
+        }, {
+          "name": "BadFlag",
+          "enabledFor": [{ "type": "made_up_type", "parameter": "accountId", "values": [1] }]
+        }]
+      )
+
+      # Must not raise, and must not return [] (the old behaviour blacked out the whole blob).
+      features = nil
+      expect { features = marshaller.unmarshall(json) }.not_to raise_error
+
+      expect(features.size).to be 2
+
+      good = features.find { |f| f.name == 'GoodFlag' }
+      bad = features.find { |f| f.name == 'BadFlag' }
+
+      # GoodFlag still evaluates normally.
+      expect(good.un_evaluable?).to be false
+      expect(good.enabled?).to be true
+
+      # BadFlag is forced OFF and never evaluates its (unparseable) condition.
+      expect(bad.un_evaluable?).to be true
+      expect(bad.enabled?).to be false
+    end
+
+    it 'should log a warning naming the flag and the unknown type' do
+      json = %([{ "name": "BadFlag", "enabledFor": [{ "type": "made_up_type" }] }])
+
+      logger = instance_double(Logger)
+      allow(EightBall).to receive(:logger).and_return(logger)
+      expect(logger).to receive(:warn) do |&block|
+        message = block.call
+        expect(message).to include('BadFlag')
+        expect(message).to include('made_up_type')
+      end
+
+      marshaller.unmarshall json
+    end
+
+    it 'should unmarshall a percentage condition' do
+      json = %(
+        [{
+          "name": "Experiment",
+          "enabledFor": [{ "type": "percentage", "parameter": "organizationId", "percentage": 25 }]
+        }]
+      )
+
+      features = marshaller.unmarshall json
+      condition = features[0].enabled_for[0]
+
+      expect(condition).to be_a EightBall::Conditions::Percentage
+      expect(condition.parameter).to eq 'organization_id'
+      expect(condition.percentage).to eq 25
+    end
+
+    it 'should fail only the offending flag closed on a malformed known condition, not raise' do
+      # A KNOWN type with invalid params (range missing min/max) raises ArgumentError
+      # from the condition constructor; it must fail that flag closed, not black out the blob.
+      json = %(
+        [{
+          "name": "GoodFlag",
+          "enabledFor": [{ "type": "always" }]
+        }, {
+          "name": "BadRange",
+          "enabledFor": [{ "type": "range", "parameter": "accountId" }]
+        }]
+      )
+
+      features = nil
+      expect { features = marshaller.unmarshall(json) }.not_to raise_error
+
+      expect(features.size).to be 2
+      expect(features.find { |f| f.name == 'GoodFlag' }.enabled?).to be true
+
+      bad = features.find { |f| f.name == 'BadRange' }
+      expect(bad.un_evaluable?).to be true
+      expect(bad.enabled?).to be false
+    end
+
+    it 'should preserve an un-evaluable flag verbatim across a marshall round-trip (no OFF->ON flip, no definition loss)' do
+      json = %([{ "name": "BadFlag", "enabledFor": [{ "type": "made_up_type", "parameter": "accountId" }] }])
+
+      once = marshaller.unmarshall(json)
+      expect(once[0].un_evaluable?).to be true
+      expect(once[0].enabled?).to be false
+
+      # Re-marshalling must re-emit the original (unparseable) condition, not drop it.
+      remarshalled = marshaller.marshall(once)
+      expect(remarshalled).to include 'made_up_type'
+
+      # Re-reading the re-marshalled blob keeps the flag fail-closed (OFF), never flips it ON.
+      twice = marshaller.unmarshall(remarshalled)
+      expect(twice[0].un_evaluable?).to be true
+      expect(twice[0].enabled?).to be false
     end
   end
 end

--- a/spec/marshallers/json_spec.rb
+++ b/spec/marshallers/json_spec.rb
@@ -72,14 +72,14 @@ RSpec.describe EightBall::Marshallers::Json do
     end
 
     it 'should marshall a percentage condition without leaking flag_name (fail-closed allowlist)' do
-      condition = EightBall::Conditions::Percentage.new(percentage: 25, parameter: 'organization_id')
+      condition = EightBall::Conditions::Percentage.new(percentage: 25, parameter: 'account_id')
       condition.flag_name = 'Experiment' # runtime injection; must NEVER appear in JSON
 
       features = [EightBall::Feature.new('Experiment', [condition])]
 
       # parameter serializes snake_case: Base#parameter= snake-cases on construction and
       # to_camelback_keys only transforms keys, not values (matches the canonical wire contract).
-      json = '[{"name":"Experiment","enabledFor":[{"type":"percentage","percentage":25,"parameter":"organization_id"}]}]'
+      json = '[{"name":"Experiment","enabledFor":[{"type":"percentage","percentage":25,"parameter":"account_id"}]}]'
 
       result = marshaller.marshall(features)
       expect(result).to eq json
@@ -94,7 +94,7 @@ RSpec.describe EightBall::Marshallers::Json do
         EightBall::Feature.new('NeverFlag', [EightBall::Conditions::Never.new]),
         EightBall::Feature.new('ListFlag', [EightBall::Conditions::List.new(values: [1, 2, 3], parameter: 'param1')]),
         EightBall::Feature.new('RangeFlag', [EightBall::Conditions::Range.new(min: 1, max: 5, parameter: 'accountId')]),
-        EightBall::Feature.new('PctFlag', [EightBall::Conditions::Percentage.new(percentage: 30, parameter: 'organizationId')])
+        EightBall::Feature.new('PctFlag', [EightBall::Conditions::Percentage.new(percentage: 30, parameter: 'accountId')])
       ]
 
       json = marshaller.marshall(features)
@@ -103,7 +103,7 @@ RSpec.describe EightBall::Marshallers::Json do
       expect(json).to include '{"type":"never"}'
       expect(json).to include '{"type":"list","values":[1,2,3],"parameter":"param1"}'
       expect(json).to include '{"type":"range","min":1,"max":5,"parameter":"account_id"}'
-      expect(json).to include '{"type":"percentage","percentage":30,"parameter":"organization_id"}'
+      expect(json).to include '{"type":"percentage","percentage":30,"parameter":"account_id"}'
     end
   end
 
@@ -239,7 +239,7 @@ RSpec.describe EightBall::Marshallers::Json do
       json = %(
         [{
           "name": "Experiment",
-          "enabledFor": [{ "type": "percentage", "parameter": "organizationId", "percentage": 25 }]
+          "enabledFor": [{ "type": "percentage", "parameter": "accountId", "percentage": 25 }]
         }]
       )
 
@@ -247,7 +247,7 @@ RSpec.describe EightBall::Marshallers::Json do
       condition = features[0].enabled_for[0]
 
       expect(condition).to be_a EightBall::Conditions::Percentage
-      expect(condition.parameter).to eq 'organization_id'
+      expect(condition.parameter).to eq 'account_id'
       expect(condition.percentage).to eq 25
     end
 

--- a/spec/marshallers/json_spec.rb
+++ b/spec/marshallers/json_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe EightBall::Marshallers::Json do
 
       features = [EightBall::Feature.new('Experiment', [condition])]
 
-      # parameter serializes snake_case: Base#parameter= snake-cases on construction and
-      # to_camelback_keys only transforms keys, not values (matches the canonical wire contract).
+      # parameter serializes snake_case: Base#parameter= snake-cases on construction, and
+      # to_camelback_keys only transforms keys, not values.
       json = '[{"name":"Experiment","enabledFor":[{"type":"percentage","percentage":25,"parameter":"account_id"}]}]'
 
       result = marshaller.marshall(features)
@@ -203,7 +203,7 @@ RSpec.describe EightBall::Marshallers::Json do
         }]
       )
 
-      # Must not raise, and must not return [] (the old behaviour blacked out the whole blob).
+      # Must not raise and must not return []; the bad flag fails closed, the rest parse.
       features = nil
       expect { features = marshaller.unmarshall(json) }.not_to raise_error
 

--- a/spec/marshallers/json_spec.rb
+++ b/spec/marshallers/json_spec.rb
@@ -291,5 +291,29 @@ RSpec.describe EightBall::Marshallers::Json do
       expect(twice[0].un_evaluable?).to be true
       expect(twice[0].enabled?).to be false
     end
+
+    it 'should fail only the offending flag closed on a non-object condition entry, not raise' do
+      # A condition entry that is not an object (string/number/null) must not blow up the
+      # whole unmarshall; it fails only that flag closed, like any other unbuildable condition.
+      json = %(
+        [{
+          "name": "GoodFlag",
+          "enabledFor": [{ "type": "always" }]
+        }, {
+          "name": "JunkFlag",
+          "enabledFor": ["not-an-object"]
+        }]
+      )
+
+      features = nil
+      expect { features = marshaller.unmarshall(json) }.not_to raise_error
+
+      expect(features.size).to be 2
+      expect(features.find { |f| f.name == 'GoodFlag' }.enabled?).to be true
+
+      junk = features.find { |f| f.name == 'JunkFlag' }
+      expect(junk.un_evaluable?).to be true
+      expect(junk.enabled?).to be false
+    end
   end
 end

--- a/spec/marshallers/json_spec.rb
+++ b/spec/marshallers/json_spec.rb
@@ -315,5 +315,33 @@ RSpec.describe EightBall::Marshallers::Json do
       expect(junk.un_evaluable?).to be true
       expect(junk.enabled?).to be false
     end
+
+    it 'should fail a flag closed on a condition with a missing or non-string type, not raise' do
+      json = %(
+        [{ "name": "Good", "enabledFor": [{ "type": "always" }] },
+         { "name": "NonStringType", "enabledFor": [{ "type": 5 }] },
+         { "name": "MissingType", "enabledFor": [{ "parameter": "account_id" }] }]
+      )
+
+      features = nil
+      expect { features = marshaller.unmarshall(json) }.not_to raise_error
+
+      expect(features.size).to be 3
+      expect(features.find { |f| f.name == 'Good' }.enabled?).to be true
+      expect(features.find { |f| f.name == 'NonStringType' }.enabled?).to be false
+      expect(features.find { |f| f.name == 'MissingType' }.enabled?).to be false
+    end
+
+    it 'should skip non-object top-level entries without dropping the healthy flags' do
+      json = %(
+        [{ "name": "Good", "enabledFor": [{ "type": "always" }] }, null, 5, "junk"]
+      )
+
+      features = nil
+      expect { features = marshaller.unmarshall(json) }.not_to raise_error
+
+      expect(features.map(&:name)).to eq ['Good']
+      expect(features.first.enabled?).to be true
+    end
   end
 end

--- a/spec/stress_spec.rb
+++ b/spec/stress_spec.rb
@@ -1,0 +1,305 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# Stress / integration suite. Drives the full unmarshall -> evaluate -> marshall cycle
+# against realistic feature-flag blobs, large blobs, adversarial input, fuzzed garbage,
+# and edge values. Evaluation parameters cover the common subject attributes a caller
+# gates on (account_id, region_name, user_id, platform, plan). All randomness is
+# seeded so runs are reproducible.
+RSpec.describe 'eight_ball stress and integration' do
+  subject(:marshaller) { EightBall::Marshallers::Json.new }
+
+  after { EightBall.provider = nil }
+
+  # A full evaluation bag (every param a consumer passes), indexed for reproducibility.
+  def bag(index)
+    {
+      account_id: "acct-#{index}",
+      region_name: "region-#{index}",
+      user_id: "user-#{index}",
+      platform: %w[web ios android api partner][index % 5],
+      plan: %w[free pro enterprise][index % 3]
+    }
+  end
+
+  describe 'realistic production-shaped blob' do
+    let(:blob) do
+      JSON.generate(
+        [
+          { name: 'AlwaysOn', enabledFor: [{ type: 'always' }] },
+          { name: 'AlwaysOff', enabledFor: [{ type: 'never' }] },
+          { name: 'RegionAllowlist', enabledFor: [{ type: 'list', parameter: 'regionName', values: %w[region-1 region-3 region-7] }] },
+          { name: 'AccountAllowlist', enabledFor: [{ type: 'list', parameter: 'accountId', values: %w[acct-2 acct-4] }] },
+          { name: 'EnterprisePlanGate', enabledFor: [{ type: 'list', parameter: 'plan', values: %w[enterprise] }] },
+          { name: 'PlatformGate', enabledFor: [{ type: 'list', parameter: 'platform', values: %w[web] }] },
+          { name: 'AccountRange', enabledFor: [{ type: 'range', parameter: 'accountId', min: 'acct-0', max: 'acct-3' }] },
+          { name: 'RolloutExperiment', enabledFor: [{ type: 'percentage', parameter: 'regionName', percentage: 25 }],
+            metadata: { type: 'experiment', owner: 'growth', expiresAt: '2026-12-31' } },
+          { name: 'GatedWithOverride', enabledFor: [{ type: 'list', parameter: 'accountId', values: %w[acct-1] }],
+            disabledFor: [{ type: 'list', parameter: 'plan', values: %w[free] }] }
+        ]
+      )
+    end
+
+    it 'evaluates every flag for a range of subjects without raising' do
+      features = marshaller.unmarshall(blob)
+      EightBall.provider = EightBall::Providers::Static.new(features)
+
+      (0..60).each do |i|
+        features.map(&:name).each do |name|
+          expect([true, false]).to include(EightBall.enabled?(name, bag(i)))
+        end
+      end
+    end
+
+    it 'produces the expected verdicts for known subjects' do
+      EightBall.provider = EightBall::Providers::Static.new(marshaller.unmarshall(blob))
+
+      expect(EightBall.enabled?('AlwaysOn', bag(0))).to be true
+      expect(EightBall.enabled?('AlwaysOff', bag(0))).to be false
+      expect(EightBall.enabled?('RegionAllowlist', region_name: 'region-3')).to be true
+      expect(EightBall.enabled?('RegionAllowlist', region_name: 'region-999')).to be false
+      expect(EightBall.enabled?('EnterprisePlanGate', plan: 'enterprise')).to be true
+      expect(EightBall.enabled?('EnterprisePlanGate', plan: 'free')).to be false
+      expect(EightBall.enabled?('PlatformGate', platform: 'web')).to be true
+      expect(EightBall.enabled?('PlatformGate', platform: 'api')).to be false
+      expect(EightBall.enabled?('AccountRange', account_id: 'acct-1')).to be true
+      expect(EightBall.enabled?('AccountRange', account_id: 'acct-8')).to be false
+      # disabled_for overrides enabled_for
+      expect(EightBall.enabled?('GatedWithOverride', account_id: 'acct-1', plan: 'pro')).to be true
+      expect(EightBall.enabled?('GatedWithOverride', account_id: 'acct-1', plan: 'free')).to be false
+      # unknown flag defaults OFF (enabled?) / ON (disabled?)
+      expect(EightBall.enabled?('DoesNotExist', bag(0))).to be false
+      expect(EightBall.disabled?('DoesNotExist', bag(0))).to be true
+    end
+
+    it 'round-trips the blob without changing any verdict' do
+      once = marshaller.unmarshall(blob)
+      twice = marshaller.unmarshall(marshaller.marshall(once))
+
+      verdicts = lambda do |features|
+        EightBall.provider = EightBall::Providers::Static.new(features)
+        features.map { |f| [f.name, EightBall.enabled?(f.name, bag(3))] }
+      end
+
+      expect(verdicts.call(twice)).to eq verdicts.call(once)
+    end
+
+    it 'preserves metadata (symbol-keyed) and camelCases it on the wire' do
+      feature = marshaller.unmarshall(blob).find { |f| f.name == 'RolloutExperiment' }
+      expect(feature.metadata).to eq(type: 'experiment', owner: 'growth', expires_at: '2026-12-31')
+      expect(marshaller.marshall([feature])).to include('"expiresAt":"2026-12-31"')
+    end
+  end
+
+  describe 'scale' do
+    def large_blob(count)
+      flags = (0...count).map do |i|
+        condition =
+          case i % 5
+          when 0 then { type: 'always' }
+          when 1 then { type: 'list', parameter: 'account_id', values: ["acct-#{i}", "acct-#{i + 1}"] }
+          when 2 then { type: 'range', parameter: 'account_id', min: 'acct-0', max: "acct-#{i}" }
+          when 3 then { type: 'percentage', parameter: 'region_name', percentage: i % 101 }
+          else { type: 'never' }
+          end
+        { name: "Flag#{i}", enabledFor: [condition] }
+      end
+      JSON.generate(flags)
+    end
+
+    it 'unmarshalls and evaluates a large mixed blob without error' do
+      features = marshaller.unmarshall(large_blob(300))
+      expect(features.size).to be 300
+      EightBall.provider = EightBall::Providers::Static.new(features)
+
+      (0..40).each do |i|
+        features.each { |f| expect([true, false]).to include(f.enabled?(bag(i))) }
+      end
+    end
+
+    it 'round-trips a large mixed blob to a stable serialization' do
+      features = marshaller.unmarshall(large_blob(300))
+      first = marshaller.marshall(features)
+      second = marshaller.marshall(marshaller.unmarshall(first))
+      expect(second).to eq first
+    end
+
+    it 'keeps percentage distribution within tolerance and sticky at scale' do
+      ids = (0...10_000).map { |i| "acct-#{i}" }
+
+      [10, 33, 80].each do |pct|
+        features = marshaller.unmarshall(
+          JSON.generate([{ name: "Exp#{pct}", enabledFor: [{ type: 'percentage', parameter: 'account_id', percentage: pct }] }])
+        )
+        EightBall.provider = EightBall::Providers::Static.new(features)
+
+        first_pass = ids.map { |id| EightBall.enabled?("Exp#{pct}", account_id: id) }
+        observed = first_pass.count(true) * 100.0 / ids.size
+        expect(observed).to be_within(3).of(pct)
+
+        second_pass = ids.map { |id| EightBall.enabled?("Exp#{pct}", account_id: id) }
+        expect(second_pass).to eq first_pass
+      end
+    end
+  end
+
+  describe 'adversarial blob (hardening at scale)' do
+    let(:blob) do
+      JSON.generate(
+        [
+          { name: 'GoodAlways', enabledFor: [{ type: 'always' }] },
+          { name: 'GoodList', enabledFor: [{ type: 'list', parameter: 'account_id', values: %w[acct-1] }] },
+          { name: 'GoodPercentage', enabledFor: [{ type: 'percentage', parameter: 'region_name', percentage: 100 }] },
+          { name: 'UnknownType', enabledFor: [{ type: 'made_up' }] },
+          { name: 'NonStringType', enabledFor: [{ type: 5 }] },
+          { name: 'MissingType', enabledFor: [{ parameter: 'account_id' }] },
+          { name: 'MalformedRange', enabledFor: [{ type: 'range', parameter: 'account_id' }] },
+          { name: 'RangeArrayBounds', enabledFor: [{ type: 'range', min: [1], max: [2] }] },
+          { name: 'NonObjectCondition', enabledFor: ['oops'] },
+          { name: 'NonArrayEnabled', enabledFor: 'not-a-list' },
+          { name: 'NonArrayDisabled', disabledFor: 42 },
+          { name: 'FloatPercentage', enabledFor: [{ type: 'percentage', parameter: 'region_name', percentage: 50.5 }] },
+          { name: 'OutOfRangePercentage', enabledFor: [{ type: 'percentage', parameter: 'region_name', percentage: 150 }] },
+          'not-even-a-feature',
+          nil,
+          { name: 'GoodNever', enabledFor: [{ type: 'never' }] }
+        ]
+      )
+    end
+
+    let(:good) { %w[GoodAlways GoodList GoodPercentage] }
+    let(:bad) do
+      %w[UnknownType NonStringType MissingType MalformedRange RangeArrayBounds
+         NonObjectCondition NonArrayEnabled NonArrayDisabled FloatPercentage OutOfRangePercentage]
+    end
+
+    it 'never raises and fails only the bad flags closed' do
+      features = nil
+      expect { features = marshaller.unmarshall(blob) }.not_to raise_error
+
+      # the two junk top-level entries are skipped; everything else becomes a feature
+      expect(features.size).to be 14
+      EightBall.provider = EightBall::Providers::Static.new(features)
+
+      expect(EightBall.enabled?('GoodAlways', bag(0))).to be true
+      expect(EightBall.enabled?('GoodList', account_id: 'acct-1')).to be true
+      expect(EightBall.enabled?('GoodPercentage', region_name: 'region-42')).to be true
+      expect(EightBall.enabled?('GoodNever', bag(0))).to be false
+
+      bad.each do |name|
+        expect(EightBall.enabled?(name, bag(0))).to be(false), "#{name} should be OFF"
+      end
+    end
+
+    it 'round-trips the adversarial blob, keeping bad flags closed and healthy flags intact' do
+      once = marshaller.unmarshall(blob)
+      twice = marshaller.unmarshall(marshaller.marshall(once))
+
+      expect(twice.size).to eq once.size
+      EightBall.provider = EightBall::Providers::Static.new(twice)
+
+      expect(EightBall.enabled?('GoodAlways', bag(0))).to be true
+      bad.each { |name| expect(EightBall.enabled?(name, bag(0))).to be false }
+    end
+  end
+
+  describe 'fuzzing' do
+    def random_json_value(rng, depth = 0)
+      choices = %i[nil int float string array]
+      choices += %i[hash condition feature] if depth < 2
+      case choices[rng.rand(choices.size)]
+      when :nil then nil
+      when :int then rng.rand(-1000..1000)
+      when :float then rng.rand * 200
+      when :string then "s#{rng.rand(10_000)}"
+      when :array then Array.new(rng.rand(0..3)) { random_json_value(rng, depth + 1) }
+      when :hash then { "k#{rng.rand(5)}" => random_json_value(rng, depth + 1) }
+      when :condition
+        { type: %w[always list range percentage made_up][rng.rand(5)],
+          parameter: %w[account_id region_name weird][rng.rand(3)],
+          values: [rng.rand(10)], min: rng.rand(5), max: rng.rand(5),
+          percentage: rng.rand(-10..120) }
+      when :feature
+        { name: "F#{rng.rand(1000)}", enabledFor: Array.new(rng.rand(0..2)) { random_json_value(rng, depth + 1) } }
+      end
+    end
+
+    it 'never raises unmarshalling random garbage, always returns an array' do
+      rng = Random.new(2024)
+      250.times do
+        entries = Array.new(rng.rand(0..6)) { random_json_value(rng) }
+        result = nil
+        expect { result = marshaller.unmarshall(JSON.generate(entries)) }.not_to raise_error
+        expect(result).to be_an(Array)
+        # nothing that parsed should throw when re-marshalled
+        expect { marshaller.marshall(result) }.not_to raise_error
+      end
+    end
+
+    it 'marshalling round-trips valid generated features idempotently' do
+      rng = Random.new(99)
+      params = %w[account_id region_name user_id platform plan]
+      60.times do
+        features = Array.new(rng.rand(1..4)) do
+          conditions = Array.new(rng.rand(0..3)) do
+            case rng.rand(5)
+            when 0 then EightBall::Conditions::Always.new
+            when 1 then EightBall::Conditions::Never.new
+            when 2 then EightBall::Conditions::List.new(values: [rng.rand(100), "v#{rng.rand(100)}"], parameter: params.sample(random: rng))
+            when 3 then EightBall::Conditions::Range.new(min: rng.rand(50), max: rng.rand(50..100), parameter: params.sample(random: rng))
+            else EightBall::Conditions::Percentage.new(percentage: rng.rand(0..100), parameter: params.sample(random: rng))
+            end
+          end
+          EightBall::Feature.new("F#{rng.rand(10_000)}", conditions, [], metadata: (rng.rand < 0.3 ? { type: 'experiment' } : nil))
+        end
+
+        once = marshaller.marshall(features)
+        twice = marshaller.marshall(marshaller.unmarshall(once))
+        expect(twice).to eq once
+      end
+    end
+  end
+
+  describe 'edge values' do
+    it 'handles unicode and control chars in names and values without crashing' do
+      weird = "flag\n\e[31m☃-#{'x' * 40}"
+      json = JSON.generate(
+        [
+          { name: weird, enabledFor: [{ type: 'list', parameter: 'account_id', values: [weird] }] },
+          { name: 'BadWeird', enabledFor: [{ type: weird }] }
+        ]
+      )
+
+      features = nil
+      expect { features = marshaller.unmarshall(json) }.not_to raise_error
+      expect { marshaller.marshall(features) }.not_to raise_error
+
+      good = features.find { |f| f.name == weird }
+      expect(good.enabled?(account_id: weird)).to be true
+      expect(features.find { |f| f.name == 'BadWeird' }.enabled?(bag(0))).to be false
+    end
+
+    it 'treats an empty array and empty-condition features sensibly' do
+      expect(marshaller.unmarshall('[]')).to eq []
+      features = marshaller.unmarshall(JSON.generate([{ name: 'NoConditions' }]))
+      expect(features.first.enabled?).to be true # no conditions => always on
+    end
+
+    it 'defaults to [] on invalid JSON, and raises consistently on any non-array top level' do
+      expect(marshaller.unmarshall('{ not json')).to eq [] # JSON::ParserError -> []
+      expect { marshaller.unmarshall('null') }.to raise_error(ArgumentError, /not an array/)
+      expect { marshaller.unmarshall('5') }.to raise_error(ArgumentError, /not an array/)
+      expect { marshaller.unmarshall('{"a":1}') }.to raise_error(ArgumentError, /not an array/)
+    end
+
+    it 'raises a clear error when a required parameter is absent (documented contract)' do
+      features = marshaller.unmarshall(
+        JSON.generate([{ name: 'NeedsAccount', enabledFor: [{ type: 'list', parameter: 'account_id', values: %w[acct-1] }] }])
+      )
+      expect { features.first.enabled?(region_name: 'region-1') }
+        .to raise_error(ArgumentError, /Missing parameter account_id/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Three additive, backward-compatible additions, shipped as 3.3.0:

1. **Percentage condition** for deterministic, sticky percentage-based bucketing. `bucket = Integer(SHA256("<flag_name>:<value>")[0,8], 16) % 100`, satisfied iff `bucket < percentage`. Salted by the flag name, so a subject is decorrelated across flags. Integer `0..100`; buckets on a caller-supplied `parameter` (like the other parameterized conditions). The canonical algorithm is documented in the README and the class docstring.
2. **Unmarshaller hardening.** A flag whose condition is unknown or malformed (unknown `type`, invalid params, or a non-object entry) now evaluates to `false` (OFF) and logs a warning, instead of raising and dropping the entire feature set. The unparseable flag round-trips verbatim, so re-serializing a blob never silently flips it on or loses its definition. Marshalling uses a fail-closed field allowlist, so runtime-only condition state is never written to the persisted blob.
3. **Optional `metadata`** (`type`, `owner`, `expires_at`) on `Feature`, round-tripped through the JSON marshaller and ignored during evaluation.

All existing conditions (`always` / `never` / `list` / `range`) and the positional `Feature.new(name, enabled_for, disabled_for)` signature are unchanged.

## Test plan

- [x] `bundle exec rake spec`: 123 examples, 0 failures, ~99.6% line coverage
- [x] Percentage: canonical bucket formula, 0/100 edges, stickiness, string coercion, cross-flag decorrelation, distribution within +/-3 points over 10k ids
- [x] Hardening: unknown, malformed, and non-object conditions each fail only their own flag closed (feature set intact), warning logged, and survive a marshall round-trip without flipping OFF to ON
- [x] Fail-closed allowlist: runtime condition state never serialized; existing condition types round-trip unchanged
- [x] Metadata: round-trips through marshall/unmarshall, absent stays nil, does not affect evaluation
- [x] CI green (RSpec on Ruby 3.4)
