### PR TITLE
fix: grant tag-and-release contents:write, release 3.3.1

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## [3.3.0]
+## [3.3.1]
 
+- Fix the `tag-and-release` workflow: grant the release job `contents: write` so tag and GitHub Release creation succeed. The repository's default GitHub Actions token permission had been changed to read-only, which broke the release step with `Resource not accessible by integration`.
 - Add `percentage` condition for sticky A/B bucketing. Canonical algorithm: `bucket = Integer(SHA256("<flagName>:<value>")[0,8], 16) % 100`, satisfied iff `bucket < percentage`; salted by flag name; buckets on a caller-supplied parameter.
 - Harden JSON unmarshalling: a flag containing an unknown or malformed condition (unknown `type`, or a known type with invalid params) now evaluates to `false` (OFF) and logs a warning, instead of raising and blacking out the entire feature set. Other flags in the blob are unaffected.
 - Add optional top-level `metadata` (`type`, `owner`, `expires_at`) to `Feature`, preserved through marshall/unmarshall and ignored during evaluation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [3.3.1]
 
 - Fix the `tag-and-release` workflow: grant the release job `contents: write` so tag and GitHub Release creation succeed. The repository's default GitHub Actions token permission had been changed to read-only, which broke the release step with `Resource not accessible by integration`.
+
+## [3.3.0]
+
 - Add `percentage` condition for sticky A/B bucketing. Canonical algorithm: `bucket = Integer(SHA256("<flagName>:<value>")[0,8], 16) % 100`, satisfied iff `bucket < percentage`; salted by flag name; buckets on a caller-supplied parameter.
 - Harden JSON unmarshalling: a flag containing an unknown or malformed condition (unknown `type`, or a known type with invalid params) now evaluates to `false` (OFF) and logs a warning, instead of raising and blacking out the entire feature set. Other flags in the blob are unaffected.
 - Add optional top-level `metadata` (`type`, `owner`, `expires_at`) to `Feature`, preserved through marshall/unmarshall and ignored during evaluation.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eight_ball (3.3.0)
+    eight_ball (3.3.1)
       awrence (~> 1.1)
       logger (~> 1.7)
       plissken (~> 1.2)

--- a/lib/eight_ball/version.rb
+++ b/lib/eight_ball/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EightBall
-  VERSION = '3.3.0'
+  VERSION = '3.3.1'
 end


### PR DESCRIPTION
## Summary

- **Fix broken releases caused by a read-only Actions token** — The `release` job in `.github/workflows/tag-and-release.yml` had no `permissions:` block, so it inherited the repository's default `GITHUB_TOKEN` scopes. That default was changed to read-only, leaving the token with `contents: read`; the `Tag commit` step (`tvdias/github-tagger`) then failed with `Resource not accessible by integration` (a 403), which left `3.3.0` un-tagged and un-published. Run `29499605441` is the failure.
- **Grant least-privilege `contents: write` to the release job** — Adds an explicit `permissions: { contents: write }` block scoped to the `release` job. This is the single scope needed by both the `Tag commit` step and the `Create Release` step (`ncipollo/release-action`); the RubyGems push authenticates with `RUBYGEMS_API_KEY`, not the token. Pinning the permission in the workflow makes releases independent of the mutable org/repo default, so a future re-hardening of that setting can't silently break them again.
- **Bump `VERSION` to `3.3.1` to re-trigger the release** — The workflow fires only on a push to `main` that touches `lib/*/version.rb`. Because `3.3.0` never shipped, bumping `lib/eight_ball/version.rb` to `3.3.1` re-arms the trigger; when this lands on `main`, the push runs the workflow under the corrected permissions and cuts the tag/release in one shot.
- **Fold the never-published `3.3.0` notes into `3.3.1`** — Renames the `## [3.3.0]` section in `CHANGELOG.md` to `## [3.3.1]` and prepends the pipeline-fix note. This keeps #43's feature notes (percentage condition, unmarshalling hardening, optional `metadata`) in the release body the workflow extracts via `awk`, with no orphan `3.3.0` entry.