### PR TITLE
fix: tag via rewind-community-tagger app token, release 3.3.2

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           app-id: ${{ secrets.TAGGER_APP_ID }}
           private-key: ${{ secrets.TAGGER_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
 
       - name: Tag commit
         uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -30,10 +30,18 @@ jobs:
           echo version=$version >> $GITHUB_OUTPUT
           echo version_tag=v$version >> $GITHUB_OUTPUT
 
+      - name: Create tagger app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.TAGGER_APP_ID }}
+          private-key: ${{ secrets.TAGGER_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Tag commit
         uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: "${{ steps.app-token.outputs.token }}"
           tag: "${{steps.get_version.outputs.version_tag}}"
 
       - name: Upload to Rubygems
@@ -72,4 +80,4 @@ jobs:
           tag: ${{steps.get_version.outputs.version_tag}}
           artifacts: "*.gem, CHANGELOG.md"
           bodyFile: "REL-BODY.md"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.3.2]
+
+- Fix the `tag-and-release` workflow to create the release tag with the `rewind-community-tagger` GitHub App token (`TAGGER_APP_ID`/`TAGGER_PRIVATE_KEY`) instead of the default `GITHUB_TOKEN`, which the organization `rewind-tag` ruleset does not permit to create `v*` tags (the previous release failed with `Reference update failed`).
+
 ## [3.3.1]
 
 - Fix the `tag-and-release` workflow: grant the release job `contents: write` so tag and GitHub Release creation succeed. The repository's default GitHub Actions token permission had been changed to read-only, which broke the release step with `Resource not accessible by integration`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eight_ball (3.3.1)
+    eight_ball (3.3.2)
       awrence (~> 1.1)
       logger (~> 1.7)
       plissken (~> 1.2)

--- a/lib/eight_ball/version.rb
+++ b/lib/eight_ball/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EightBall
-  VERSION = '3.3.1'
+  VERSION = '3.3.2'
 end


### PR DESCRIPTION
## Summary

- **Create release tags via the `rewind-community-tagger` GitHub App instead of `GITHUB_TOKEN`** — The `v3.3.1` release failed at the tag step with `Reference update failed`. The org-level tag ruleset `rewind-tag` restricts creation of all `v*` tags to bypass actors (org admins and the `rewind-community-tagger` app); the default `GITHUB_TOKEN` is not a bypass actor, so it cannot create the tag. This adds a `Create tagger app token` step (`actions/create-github-app-token`, using the org-provisioned `TAGGER_APP_ID` / `TAGGER_PRIVATE_KEY` secrets) and points both `Tag commit` (`repo-token`) and `Create Release` (`token`) at `steps.app-token.outputs.token`.
- **Scope the default `GITHUB_TOKEN` to `contents: read`** — With tagging and release now using the app token, `actions/checkout` is the only remaining consumer of the default token and needs read only. Dropping the previous `contents: write` grant to `contents: read` restores least-privilege. Kept explicit (rather than removed) so the workflow doesn't re-depend on the mutable org/repo default token setting.
- **Bump to `3.3.2` to re-trigger the release** — `version.rb` was already `3.3.1` on `main` and no `v3.3.1` tag was ever created, so `version.rb` and `Gemfile.lock` are bumped `3.3.1 → 3.3.2`; merging this re-fires the `paths: lib/*/version.rb` trigger and cuts `v3.3.2` under the fixed workflow. `3.3.1` was never published and is skipped.
- **Document the fix in `CHANGELOG.md`** — Adds a `## [3.3.2]` section describing the tagger-app change, kept separate from the `3.3.1` / `3.3.0` sections.