### PR TITLE
feat: treat a missing parameter as unsatisfied instead of raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Evaluating a feature no longer raises when a referenced parameter is absent from the supplied parameters; the condition is treated as unsatisfied instead. Supplying no parameters at all still raises.
+
 ## [3.3.2]
 
 - Fix the `tag-and-release` workflow to create the release tag with the `rewind-community-tagger` GitHub App token (`TAGGER_APP_ID`/`TAGGER_PRIVATE_KEY`) instead of the default `GITHUB_TOKEN`, which the organization `rewind-tag` ruleset does not permit to create `v*` tags (the previous release failed with `Reference update failed`).

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The salt is the **flag name**, so the same `account_id` lands in independent buc
 
 **Re-randomizing requires a rename.** Because the salt is the flag name, an experiment cannot be re-randomized on the same flag. The salt is stable for the life of the name (this is what decorrelates a subject across flags), so a subject's bucket for a given flag is fixed forever. Changing `percentage` only moves the threshold (it does not reshuffle buckets); to draw fresh buckets, rename the flag.
 
-**Requires the bucketing parameter.** Like every parameterized condition, `percentage` requires its bucketing value (the `parameter` it was configured with) in the evaluation bag. If it is absent, evaluation raises `ArgumentError`; supply it or rescue.
+**Requires the bucketing parameter.** Like every parameterized condition, `percentage` is concerned with its bucketing value (the `parameter` it was configured with). If a non-empty evaluation bag omits it, the condition is simply treated as unsatisfied; evaluating with no parameters at all raises `ArgumentError`.
 
 ### Metadata
 

--- a/lib/eight_ball/feature.rb
+++ b/lib/eight_ball/feature.rb
@@ -37,8 +37,9 @@ module EightBall
     #   and NONE of the {disabled_for} {EightBall::Conditions} are satisfied.
     # @return [false ] if ANY of the {disabled_for} {EightBall::Conditions} are satisfied
     #
-    # @raise [ArgumentError] if no value is provided for a parameter required
-    #   by one of the Feature's {EightBall::Conditions}
+    # @raise [ArgumentError] if +parameters+ is empty and one of the Feature's
+    #   {EightBall::Conditions} requires a parameter. A condition whose parameter
+    #   is simply absent from a non-empty +parameters+ is treated as unsatisfied.
     #
     # @example The Feature's {EightBall::Conditions} do not require any parameters
     #   feature.enabled?
@@ -85,7 +86,14 @@ module EightBall
         return condition.satisfied? if condition.parameter.nil?
 
         value = parameters[condition.parameter.to_sym]
-        raise ArgumentError, "Missing parameter #{condition.parameter}" if value.nil?
+        if value.nil?
+          # A caller that supplies some parameters but not this one leaves the
+          # condition unsatisfied; a caller that supplies none at all is a
+          # usage error.
+          raise ArgumentError, 'At least one parameter is required' if parameters.empty?
+
+          next false
+        end
 
         condition.satisfied? value
       end

--- a/spec/feature_spec.rb
+++ b/spec/feature_spec.rb
@@ -61,11 +61,50 @@ RSpec.describe EightBall::Feature do
       expect(feature.enabled?).to be false
     end
 
-    it 'should raise an Exception if a parameter is missing' do
+    it 'should raise an Exception if evaluated with no parameters at all' do
       condition = EightBall::Conditions::List.new parameter: 'param1', values: [1, 2]
       feature = EightBall::Feature.new 'Feature', condition
 
-      expect { feature.enabled? }.to raise_error ArgumentError, 'Missing parameter param1'
+      expect { feature.enabled? }.to raise_error ArgumentError, 'At least one parameter is required'
+    end
+
+    it 'should treat a condition as unsatisfied if its parameter is absent from a non-empty bag' do
+      condition = EightBall::Conditions::List.new parameter: 'param1', values: [1, 2]
+      feature = EightBall::Feature.new 'Feature', condition
+
+      expect(feature.enabled?(other_param: 1)).to be false
+    end
+
+    it 'should not raise when one of several enabledFor conditions is missing its parameter' do
+      matching = EightBall::Conditions::List.new parameter: 'plan', values: %w[pro enterprise]
+      other = EightBall::Conditions::List.new parameter: 'account_id', values: [1, 2]
+
+      feature = EightBall::Feature.new 'Feature', [matching, other]
+
+      expect(feature.enabled?(plan: 'pro')).to be true
+      expect(feature.enabled?(plan: 'free')).to be false
+    end
+
+    it 'should short-circuit before reaching a later condition with an unsupplied parameter' do
+      satisfied = EightBall::Conditions::Always.new
+      later = EightBall::Conditions::List.new parameter: 'account_id', values: [1, 2]
+
+      feature = EightBall::Feature.new 'Feature', [satisfied, later]
+
+      expect(feature.enabled?).to be true
+    end
+
+    it 'should not raise for a bare feature evaluated with an empty parameters hash' do
+      feature = EightBall::Feature.new 'NoConditions'
+
+      expect(feature.enabled?({})).to be true
+    end
+
+    it 'should not disable when a disabledFor condition parameter is absent from a non-empty bag' do
+      disabled_on_missing = EightBall::Conditions::List.new parameter: 'account_id', values: [1, 2]
+      feature = EightBall::Feature.new 'Feature', [], [disabled_on_missing]
+
+      expect(feature.enabled?(other_param: 1)).to be true
     end
 
     it 'should pass parameter to satisfied?' do

--- a/spec/stress_spec.rb
+++ b/spec/stress_spec.rb
@@ -294,12 +294,13 @@ RSpec.describe 'eight_ball stress and integration' do
       expect { marshaller.unmarshall('{"a":1}') }.to raise_error(ArgumentError, /not an array/)
     end
 
-    it 'raises a clear error when a required parameter is absent (documented contract)' do
+    it 'treats a required parameter absent from a non-empty bag as unsatisfied, but raises on an empty bag (documented contract)' do
       features = marshaller.unmarshall(
         JSON.generate([{ name: 'NeedsAccount', enabledFor: [{ type: 'list', parameter: 'account_id', values: %w[acct-1] }] }])
       )
-      expect { features.first.enabled?(region_name: 'region-1') }
-        .to raise_error(ArgumentError, /Missing parameter account_id/)
+      expect(features.first.enabled?(region_name: 'region-1')).to be false
+      expect { features.first.enabled?({}) }
+        .to raise_error(ArgumentError, /At least one parameter is required/)
     end
   end
 end


### PR DESCRIPTION
## What

`Feature#enabled?` no longer raises when a condition references a parameter that isn't present in the supplied parameters. That condition is treated as unsatisfied instead, so evaluation continues normally (OR across `enabledFor`, and `disabledFor` still wins).

Supplying no parameters at all still raises `ArgumentError` ("At least one parameter is required"), so a call that forgets to pass parameters is still caught.

## Why

A feature can reference several parameters (for example one condition on `plan` and another on `account_id`), and different call sites may only know a subset of them. Previously, evaluating such a feature from a call site that supplied only some of its parameters raised, even when the supplied parameters were already enough to decide the result. Now a caller can pass just the parameters it has; conditions it cannot evaluate simply do not match.

## Behavior

- Partial parameters: an absent parameter leaves its condition unsatisfied (no raise).
- Empty parameters on a feature that has parameterized conditions: still raises.
- Parameter-less conditions (`always`/`never`) and a short-circuiting earlier match are unaffected.

## Notes

This is a behavioral change: callers that relied on the previous per-parameter "Missing parameter" raise to detect a specific absent parameter will no longer get it (except for the empty-parameters case). Tests and CHANGELOG are updated.
