### PR TITLE
fix: compact nil conditions before marshalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.3.3]
+
+- Add `.compact` before each `.map(&:to_wire)` so stray nil conditions are
+dropped instead of blowing up serialization
+
 ## [3.3.2]
 
 - Fix the `tag-and-release` workflow to create the release tag with the `rewind-community-tagger` GitHub App token (`TAGGER_APP_ID`/`TAGGER_PRIVATE_KEY`) instead of the default `GITHUB_TOKEN`, which the organization `rewind-tag` ruleset does not permit to create `v*` tags (the previous release failed with `Reference update failed`).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eight_ball (3.3.2)
+    eight_ball (3.3.3)
       awrence (~> 1.1)
       logger (~> 1.7)
       plissken (~> 1.2)

--- a/lib/eight_ball/marshallers/json.rb
+++ b/lib/eight_ball/marshallers/json.rb
@@ -105,11 +105,11 @@ module EightBall::Marshallers
         name: feature.name
       }
 
-enabled_for = feature.enabled_for.compact
-hash[:enabled_for] = enabled_for.map(&:to_wire) unless enabled_for.empty?
+      enabled_for = feature.enabled_for.compact
+      hash[:enabled_for] = enabled_for.map(&:to_wire) unless enabled_for.empty?
 
-disabled_for = feature.disabled_for.compact
-hash[:disabled_for] = disabled_for.map(&:to_wire) unless disabled_for.empty?
+      disabled_for = feature.disabled_for.compact
+      hash[:disabled_for] = disabled_for.map(&:to_wire) unless disabled_for.empty?
       hash[:metadata] = feature.metadata unless feature.metadata.nil?
 
       hash

--- a/lib/eight_ball/marshallers/json.rb
+++ b/lib/eight_ball/marshallers/json.rb
@@ -105,8 +105,11 @@ module EightBall::Marshallers
         name: feature.name
       }
 
-      hash[:enabled_for] = feature.enabled_for.compact.map(&:to_wire) unless feature.enabled_for.empty?
-      hash[:disabled_for] = feature.disabled_for.compact.map(&:to_wire) unless feature.disabled_for.empty?
+enabled_for = feature.enabled_for.compact
+hash[:enabled_for] = enabled_for.map(&:to_wire) unless enabled_for.empty?
+
+disabled_for = feature.disabled_for.compact
+hash[:disabled_for] = disabled_for.map(&:to_wire) unless disabled_for.empty?
       hash[:metadata] = feature.metadata unless feature.metadata.nil?
 
       hash

--- a/lib/eight_ball/marshallers/json.rb
+++ b/lib/eight_ball/marshallers/json.rb
@@ -105,8 +105,8 @@ module EightBall::Marshallers
         name: feature.name
       }
 
-      hash[:enabled_for] = feature.enabled_for.map(&:to_wire) unless feature.enabled_for.empty?
-      hash[:disabled_for] = feature.disabled_for.map(&:to_wire) unless feature.disabled_for.empty?
+      hash[:enabled_for] = feature.enabled_for.compact.map(&:to_wire) unless feature.enabled_for.empty?
+      hash[:disabled_for] = feature.disabled_for.compact.map(&:to_wire) unless feature.disabled_for.empty?
       hash[:metadata] = feature.metadata unless feature.metadata.nil?
 
       hash

--- a/lib/eight_ball/version.rb
+++ b/lib/eight_ball/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EightBall
-  VERSION = '3.3.2'
+  VERSION = '3.3.3'
 end


### PR DESCRIPTION
feature_to_hash called `.map(&:to_wire)` on enabled_for/disabled_for
without stripping nils, so a condition array containing nil raised
`undefined method 'to_wire' for nil`. The `unless …empty?` guard only
catches [], not [nil].
Add `.compact` before each `.map(&:to_wire)` so stray nil conditions are
dropped instead of blowing up serialization. Regressed in 3.3.0 (#43);
surfaced in rewind-admin's feature-flag update path.
