### PR TITLE
feat: add opt-in string coercion to List value matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.4.0]
+
+- Add an opt-in `coerce` boolean to the `list` condition. When `true`, values and the tested input are compared as strings, so a list authored with integers matches a string caller (and vice versa). Defaults to exact-type matching, so existing definitions are unchanged; the flag is serialized only when enabled.
+
 ## [3.3.3]
 
 - Add `.compact` before each `.map(&:to_wire)` so stray nil conditions are

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eight_ball (3.3.3)
+    eight_ball (3.4.0)
       awrence (~> 1.1)
       logger (~> 1.7)
       plissken (~> 1.2)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ A Condition must either be `true` or `false`. It describes when a Feature is ena
 - [Range](lib/eight_ball/conditions/range.rb): This condition is satisfied if the given value is within the specified range (inclusive).
 - [Percentage](lib/eight_ball/conditions/percentage.rb): This condition is satisfied for a deterministic, sticky subset of subjects sized to `percentage` percent. Bucketing is salted by the flag name so a subject is decorrelated across flags. Wire form: `{"type":"percentage","parameter":"account_id","percentage":<0..100>}`.
 
+#### List value coercion
+
+By default a `list` matches by exact type, so an integer value never matches a string (and vice versa). Set `coerce: true` on a list to compare both sides as strings, so an integer-authored list matches a string caller. The default stays exact, and the field is serialized only when enabled. Wire form: `{"type":"list","parameter":"account_id","values":[2,3],"coerce":true}`.
+
 #### Sticky percentage bucketing
 
 The `percentage` condition buckets a subject deterministically:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ A Condition must either be `true` or `false`. It describes when a Feature is ena
 
 By default a `list` matches by exact type, so an integer value never matches a string (and vice versa). Set `coerce: true` on a list to compare both sides as strings, so an integer-authored list matches a string caller. The default stays exact, and the field is serialized only when enabled. Wire form: `{"type":"list","parameter":"account_id","values":[2,3],"coerce":true}`.
 
+Coercion is exact string comparison (`value.to_s`), not numeric or fuzzy: `1.0` does not match a `[1]` list, and `nil`/`""` share a string form. It is intended for scalar id/name lists. Cross-version note: a reader on a pre-`coerce` gem ignores the field and matches exactly, so a `coerce:true` flag can evaluate differently across gem versions until every reader is upgraded.
+
 #### Sticky percentage bucketing
 
 The `percentage` condition buckets a subject deterministically:

--- a/lib/eight_ball/conditions/list.rb
+++ b/lib/eight_ball/conditions/list.rb
@@ -4,7 +4,7 @@ module EightBall::Conditions
   # The List Condition describes a list of acceptable values.
   # These can be strings, integers, etc.
   class List < Base
-    attr_reader :values
+    attr_reader :values, :coerce
 
     # Creates a new instance of a List Condition.
     #
@@ -16,10 +16,14 @@ module EightBall::Conditions
     #   The name of the parameter this Condition was created for (eg. "account_id").
     #   This value is only used by calling classes as a way to know what to pass
     #   into {satisfied?}.
+    # @option options [Boolean] :coerce
+    #   When true, compare values and the tested input as strings so that, eg.,
+    #   an integer list matches a string caller. Defaults to exact-type matching.
     def initialize(options = {})
       options ||= {}
 
       @values = Array(options[:values])
+      @coerce = options[:coerce] || nil
       self.parameter = options[:parameter]
     end
 
@@ -29,17 +33,19 @@ module EightBall::Conditions
     #   condition.satisfied? 2 => false
     #   condition.satisfied? 'a' => true
     def satisfied?(value)
+      return values.map(&:to_s).include?(value.to_s) if @coerce
+
       values.include? value
     end
 
     def wire_fields
-      %i[values parameter]
+      %i[values parameter coerce]
     end
 
     protected
 
     def state
-      super + [@values.sort]
+      super + [@values.sort, @coerce]
     end
   end
 end

--- a/lib/eight_ball/conditions/list.rb
+++ b/lib/eight_ball/conditions/list.rb
@@ -43,7 +43,9 @@ module EightBall::Conditions
     end
 
     def wire_fields
-      %i[values parameter coerce]
+      # coerce before parameter so the wire key order matches the eight-ball-ts
+      # port (whose parameter is always emitted last), keeping the two byte-identical.
+      %i[values coerce parameter]
     end
 
     protected

--- a/lib/eight_ball/conditions/list.rb
+++ b/lib/eight_ball/conditions/list.rb
@@ -29,7 +29,7 @@ module EightBall::Conditions
     end
 
     # @example
-    #   condition = new EightBall::Conditions::List.new [1, 'a']
+    #   condition = EightBall::Conditions::List.new(values: [1, 'a'])
     #   condition.satisfied? 1 => true
     #   condition.satisfied? 2 => false
     #   condition.satisfied? 'a' => true

--- a/lib/eight_ball/conditions/list.rb
+++ b/lib/eight_ball/conditions/list.rb
@@ -23,7 +23,8 @@ module EightBall::Conditions
       options ||= {}
 
       @values = Array(options[:values])
-      @coerce = options[:coerce] || nil
+      # Store a canonical true/nil so the wire never carries a stray non-boolean.
+      @coerce = options[:coerce] ? true : nil
       self.parameter = options[:parameter]
     end
 
@@ -33,7 +34,10 @@ module EightBall::Conditions
     #   condition.satisfied? 2 => false
     #   condition.satisfied? 'a' => true
     def satisfied?(value)
-      return values.map(&:to_s).include?(value.to_s) if @coerce
+      if @coerce
+        string_value = value.to_s
+        return values.any? { |v| v.to_s == string_value }
+      end
 
       values.include? value
     end
@@ -45,7 +49,9 @@ module EightBall::Conditions
     protected
 
     def state
-      super + [@values.sort, @coerce]
+      # sort_by(&:to_s) so a mixed-type list (eg. the int/string values coerce
+      # is built for) does not raise ArgumentError in ==/hash.
+      super + [@values.sort_by(&:to_s), @coerce]
     end
   end
 end

--- a/lib/eight_ball/version.rb
+++ b/lib/eight_ball/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EightBall
-  VERSION = '3.3.3'
+  VERSION = '3.4.0'
 end

--- a/spec/conditions/list_spec.rb
+++ b/spec/conditions/list_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe EightBall::Conditions::List do
       it 'should still return false for a non-member' do
         expect(EightBall::Conditions::List.new(values: [1, 2], coerce: true).satisfied?('3')).to eq false
       end
+
+      it 'should normalize a truthy value to a canonical boolean so the wire carries no stray value' do
+        expect(EightBall::Conditions::List.new(values: [1], coerce: 1).coerce).to be true
+        expect(EightBall::Conditions::List.new(values: [1], coerce: false).coerce).to be_nil
+      end
+
+      it 'should compare mixed-type coerced Lists without raising' do
+        c1 = EightBall::Conditions::List.new(parameter: 'id', values: [1, '2'], coerce: true)
+        c2 = EightBall::Conditions::List.new(parameter: 'id', values: ['2', 1], coerce: true)
+        expect(c1 == c2).to be true
+      end
     end
   end
 

--- a/spec/conditions/list_spec.rb
+++ b/spec/conditions/list_spec.rb
@@ -48,7 +48,13 @@ RSpec.describe EightBall::Conditions::List do
         expect(EightBall::Conditions::List.new(values: [1, 2], coerce: true).satisfied?('3')).to eq false
       end
 
-      it 'should normalize a truthy value to a canonical boolean so the wire carries no stray value' do
+      it 'compares by exact string form: 1.0 does not match 1, and nil/empty share a form' do
+        expect(EightBall::Conditions::List.new(values: [1], coerce: true).satisfied?(1.0)).to eq false
+        expect(EightBall::Conditions::List.new(values: [1], coerce: true).satisfied?(nil)).to eq false
+        expect(EightBall::Conditions::List.new(values: [nil], coerce: true).satisfied?('')).to eq true
+      end
+
+      it 'should normalize a truthy value to a canonical boolean' do
         expect(EightBall::Conditions::List.new(values: [1], coerce: 1).coerce).to be true
         expect(EightBall::Conditions::List.new(values: [1], coerce: false).coerce).to be_nil
       end

--- a/spec/conditions/list_spec.rb
+++ b/spec/conditions/list_spec.rb
@@ -32,6 +32,22 @@ RSpec.describe EightBall::Conditions::List do
       list2 = EightBall::Conditions::List.new values: %w[John Jim]
       expect(list2.satisfied?('Jeremy')).to eq false
     end
+
+    it 'should not coerce types by default' do
+      expect(EightBall::Conditions::List.new(values: [1]).satisfied?('1')).to eq false
+      expect(EightBall::Conditions::List.new(values: ['1']).satisfied?(1)).to eq false
+    end
+
+    context 'when coerce is enabled' do
+      it 'should match across types by comparing both sides as strings' do
+        expect(EightBall::Conditions::List.new(values: [1], coerce: true).satisfied?('1')).to eq true
+        expect(EightBall::Conditions::List.new(values: ['1'], coerce: true).satisfied?(1)).to eq true
+      end
+
+      it 'should still return false for a non-member' do
+        expect(EightBall::Conditions::List.new(values: [1, 2], coerce: true).satisfied?('3')).to eq false
+      end
+    end
   end
 
   describe '==' do
@@ -59,6 +75,13 @@ RSpec.describe EightBall::Conditions::List do
     it 'should return false for Lists with different paramter names' do
       c1 = EightBall::Conditions::List.new parameter: 'id', values: [1, 2, 3]
       c2 = EightBall::Conditions::Base.new parameter: 'id2', values: [1, 2, 3]
+
+      expect(c1 == c2).to be false
+    end
+
+    it 'should return false for Lists that differ only in coerce' do
+      c1 = EightBall::Conditions::List.new parameter: 'id', values: [1, 2, 3]
+      c2 = EightBall::Conditions::List.new parameter: 'id', values: [1, 2, 3], coerce: true
 
       expect(c1 == c2).to be false
     end

--- a/spec/conditions/list_spec.rb
+++ b/spec/conditions/list_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe EightBall::Conditions::List do
     end
 
     it 'should not coerce types by default' do
+      # The exact-type match still succeeds, so a regression in the non-coerce path is caught.
+      expect(EightBall::Conditions::List.new(values: [1]).satisfied?(1)).to eq true
       expect(EightBall::Conditions::List.new(values: [1]).satisfied?('1')).to eq false
       expect(EightBall::Conditions::List.new(values: ['1']).satisfied?(1)).to eq false
     end

--- a/spec/marshallers/json_spec.rb
+++ b/spec/marshallers/json_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe EightBall::Marshallers::Json do
       expect(result).not_to include 'flag_name'
     end
 
+    it 'should serialize coerce on a list condition only when enabled' do
+      coerced = [
+        EightBall::Feature.new('Coerced', [EightBall::Conditions::List.new(values: [1], parameter: 'param1', coerce: true)])
+      ]
+      expect(marshaller.marshall(coerced)).to include '"coerce":true'
+
+      default = [
+        EightBall::Feature.new('Default', [EightBall::Conditions::List.new(values: [1], parameter: 'param1')])
+      ]
+      expect(marshaller.marshall(default)).not_to include 'coerce'
+    end
+
     it 'should round-trip every condition type through the allowlist unchanged' do
       features = [
         EightBall::Feature.new('AlwaysFlag', [EightBall::Conditions::Always.new]),
@@ -150,6 +162,20 @@ RSpec.describe EightBall::Marshallers::Json do
       expect(features[1].enabled_for[0].values).to contain_exactly 1, 2, 3, 4
       expect(features[1].disabled_for.size).to be 1
       expect(features[1].disabled_for[0]).to be_a EightBall::Conditions::Never
+    end
+
+    it 'should round-trip a coerce-enabled list condition' do
+      json = %([{ "name": "Coerced", "enabledFor": [{ "type": "list", "parameter": "param1", "values": [1], "coerce": true }] }])
+
+      features = marshaller.unmarshall(json)
+      condition = features[0].enabled_for[0]
+
+      expect(condition).to be_a EightBall::Conditions::List
+      expect(condition.coerce).to be true
+      expect(condition.satisfied?('1')).to be true
+
+      # Re-marshalling preserves the coerce flag.
+      expect(marshaller.marshall(features)).to include '"coerce":true'
     end
 
     it 'should default to [] if JSON parsing error occurs' do

--- a/spec/marshallers/json_spec.rb
+++ b/spec/marshallers/json_spec.rb
@@ -98,6 +98,19 @@ RSpec.describe EightBall::Marshallers::Json do
         EightBall::Feature.new('Default', [EightBall::Conditions::List.new(values: [1], parameter: 'param1')])
       ]
       expect(marshaller.marshall(default)).not_to include 'coerce'
+
+      # A truthy non-boolean serializes as a canonical true, never the raw value.
+      truthy = [
+        EightBall::Feature.new('Truthy', [EightBall::Conditions::List.new(values: [1], parameter: 'param1', coerce: 1)])
+      ]
+      expect(marshaller.marshall(truthy)).to include '"coerce":true'
+      expect(marshaller.marshall(truthy)).not_to include '"coerce":1'
+
+      # An explicit false is omitted from the wire, same as the default.
+      explicit_false = [
+        EightBall::Feature.new('ExplicitFalse', [EightBall::Conditions::List.new(values: [1], parameter: 'param1', coerce: false)])
+      ]
+      expect(marshaller.marshall(explicit_false)).not_to include 'coerce'
     end
 
     it 'should round-trip every condition type through the allowlist unchanged' do

--- a/spec/marshallers/json_spec.rb
+++ b/spec/marshallers/json_spec.rb
@@ -92,7 +92,9 @@ RSpec.describe EightBall::Marshallers::Json do
       coerced = [
         EightBall::Feature.new('Coerced', [EightBall::Conditions::List.new(values: [1], parameter: 'param1', coerce: true)])
       ]
-      expect(marshaller.marshall(coerced)).to include '"coerce":true'
+      # Exact substring, so the key order (coerce before parameter) that keeps the
+      # wire byte-identical with eight-ball-ts cannot silently regress.
+      expect(marshaller.marshall(coerced)).to include '"values":[1],"coerce":true,"parameter":"param1"'
 
       default = [
         EightBall::Feature.new('Default', [EightBall::Conditions::List.new(values: [1], parameter: 'param1')])


### PR DESCRIPTION
## Summary
Adds an opt-in `coerce` boolean to the `List` condition. By default `List#satisfied?` matches by exact type (`values.include?(value)`), so a list authored with integers never matches a string caller and vice versa. When `coerce: true`, both the list values and the tested input are compared as strings (`values.map(&:to_s).include?(value.to_s)`), making the match type-tolerant.

## Behavior
- Default unchanged: `coerce` defaults to nil and matching stays exact-type, so existing definitions and consumers behave identically.
- Backward-compatible wire format: `coerce` is serialized only when `true` (nil/false is omitted), so existing serialized blobs are untouched and older gem versions simply ignore the field.
- `coerce` participates in condition equality.

## Tests
- Exact-type default preserved; coerce matches across Integer/String in both directions; non-members still excluded.
- JSON round-trip: `coerce: true` persists and rebuilds enabled; a default list omits the key (never emits `coerce: false`).
- Equality distinguishes two lists that differ only in `coerce`.

Minor version bump 3.3.3 to 3.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
